### PR TITLE
Add CRUD flows for core CRM models

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+build
+dist

--- a/src/business/services/ChatterService.ts
+++ b/src/business/services/ChatterService.ts
@@ -1,0 +1,31 @@
+import {inject, injectable} from "tsyringe";
+import {IChatterRepository} from "../../data/interfaces/IChatterRepository";
+import {ChatterModel} from "../models/ChatterModel";
+import {ChatterStatus, CurrencySymbol} from "../../rename/types";
+
+@injectable()
+export class ChatterService {
+    constructor(
+        @inject("IChatterRepository") private chatterRepo: IChatterRepository
+    ) {}
+
+    public async getAll(): Promise<ChatterModel[]> {
+        return this.chatterRepo.findAll();
+    }
+
+    public async getById(id: number): Promise<ChatterModel | null> {
+        return this.chatterRepo.findById(id);
+    }
+
+    public async create(data: { email: string; currency: CurrencySymbol; commissionRate: number; platformFee: number; status: ChatterStatus; }): Promise<ChatterModel> {
+        return this.chatterRepo.create(data);
+    }
+
+    public async update(id: number, data: { email?: string; currency?: CurrencySymbol; commissionRate?: number; platformFee?: number; status?: ChatterStatus; }): Promise<ChatterModel | null> {
+        return this.chatterRepo.update(id, data);
+    }
+
+    public async delete(id: number): Promise<void> {
+        await this.chatterRepo.delete(id);
+    }
+}

--- a/src/business/services/EmployeeEarningService.ts
+++ b/src/business/services/EmployeeEarningService.ts
@@ -1,0 +1,30 @@
+import {inject, injectable} from "tsyringe";
+import {IEmployeeEarningRepository} from "../../data/interfaces/IEmployeeEarningRepository";
+import {EmployeeEarningModel} from "../models/EmployeeEarningModel";
+
+@injectable()
+export class EmployeeEarningService {
+    constructor(
+        @inject("IEmployeeEarningRepository") private earningRepo: IEmployeeEarningRepository
+    ) {}
+
+    public async getAll(): Promise<EmployeeEarningModel[]> {
+        return this.earningRepo.findAll();
+    }
+
+    public async getById(id: number): Promise<EmployeeEarningModel | null> {
+        return this.earningRepo.findById(id);
+    }
+
+    public async create(data: { chatterId: number; date: Date; amount: number; description?: string | null; }): Promise<EmployeeEarningModel> {
+        return this.earningRepo.create(data);
+    }
+
+    public async update(id: number, data: { chatterId?: number; date?: Date; amount?: number; description?: string | null; }): Promise<EmployeeEarningModel | null> {
+        return this.earningRepo.update(id, data);
+    }
+
+    public async delete(id: number): Promise<void> {
+        await this.earningRepo.delete(id);
+    }
+}

--- a/src/business/services/ShiftService.ts
+++ b/src/business/services/ShiftService.ts
@@ -1,0 +1,31 @@
+import {inject, injectable} from "tsyringe";
+import {IShiftRepository} from "../../data/interfaces/IShiftRepository";
+import {ShiftModel} from "../models/ShiftModel";
+import {ShiftStatus} from "../../rename/types";
+
+@injectable()
+export class ShiftService {
+    constructor(
+        @inject("IShiftRepository") private shiftRepo: IShiftRepository
+    ) {}
+
+    public async getAll(): Promise<ShiftModel[]> {
+        return this.shiftRepo.findAll();
+    }
+
+    public async getById(id: number): Promise<ShiftModel | null> {
+        return this.shiftRepo.findById(id);
+    }
+
+    public async create(data: { chatterId: number; date: Date; startTime: Date; endTime: Date; status: ShiftStatus; }): Promise<ShiftModel> {
+        return this.shiftRepo.create(data);
+    }
+
+    public async update(id: number, data: { chatterId?: number; date?: Date; startTime?: Date; endTime?: Date; status?: ShiftStatus; }): Promise<ShiftModel | null> {
+        return this.shiftRepo.update(id, data);
+    }
+
+    public async delete(id: number): Promise<void> {
+        await this.shiftRepo.delete(id);
+    }
+}

--- a/src/business/services/UserService.ts
+++ b/src/business/services/UserService.ts
@@ -2,6 +2,8 @@ import {inject, injectable} from "tsyringe";
 import {IUserRepository} from "../../data/interfaces/IUserRepository";
 import bcrypt from "bcrypt";
 import jwt from "jsonwebtoken";
+import {UserModel} from "../models/UserModel";
+import {Role} from "../../rename/types";
 
 @injectable()
 export class UserService {
@@ -9,11 +11,42 @@ export class UserService {
         @inject("IUserRepository") private userRepo: IUserRepository
     ) {}
 
+    public async getAll(): Promise<UserModel[]> {
+        return this.userRepo.findAll();
+    }
+
+    public async getById(id: number): Promise<UserModel | null> {
+        return this.userRepo.findById(id);
+    }
+
+    public async create(data: { username: string; password: string; fullName: string; role: Role; }): Promise<UserModel> {
+        const passwordHash = await bcrypt.hash(data.password, 10);
+        return this.userRepo.create({
+            username: data.username,
+            passwordHash,
+            fullName: data.fullName,
+            role: data.role,
+        });
+    }
+
+    public async update(id: number, data: { username?: string; password?: string; fullName?: string; role?: Role; }): Promise<UserModel | null> {
+        const updateData: any = { ...data };
+        if (data.password) {
+            updateData.passwordHash = await bcrypt.hash(data.password, 10);
+            delete updateData.password;
+        }
+        return this.userRepo.update(id, updateData);
+    }
+
+    public async delete(id: number): Promise<void> {
+        await this.userRepo.delete(id);
+    }
+
     public async login(email: string, password: string): Promise<string | null> {
         const user = await this.userRepo.findByEmail(email);
         if (!user) return null;
 
-        const valid = await bcrypt.compare(password, user.password);
+        const valid = await bcrypt.compare(password, user.passwordHash);
         if (!valid) return null;
 
         return jwt.sign(

--- a/src/container/index.ts
+++ b/src/container/index.ts
@@ -2,9 +2,33 @@ import {container} from "tsyringe";
 import {UserService} from "../business/services/UserService";
 import {IUserRepository} from "../data/interfaces/IUserRepository";
 import {UserRepository} from "../data/repositories/UserRepository";
+import {ChatterService} from "../business/services/ChatterService";
+import {IChatterRepository} from "../data/interfaces/IChatterRepository";
+import {ChatterRepository} from "../data/repositories/ChatterRepository";
+import {EmployeeEarningService} from "../business/services/EmployeeEarningService";
+import {IEmployeeEarningRepository} from "../data/interfaces/IEmployeeEarningRepository";
+import {EmployeeEarningRepository} from "../data/repositories/EmployeeEarningRepository";
+import {ShiftService} from "../business/services/ShiftService";
+import {IShiftRepository} from "../data/interfaces/IShiftRepository";
+import {ShiftRepository} from "../data/repositories/ShiftRepository";
 
 container.register("UserService", { useClass: UserService });
 
 container.register<IUserRepository>("IUserRepository", {
     useClass: UserRepository,
+});
+
+container.register("ChatterService", { useClass: ChatterService });
+container.register<IChatterRepository>("IChatterRepository", {
+    useClass: ChatterRepository,
+});
+
+container.register("EmployeeEarningService", { useClass: EmployeeEarningService });
+container.register<IEmployeeEarningRepository>("IEmployeeEarningRepository", {
+    useClass: EmployeeEarningRepository,
+});
+
+container.register("ShiftService", { useClass: ShiftService });
+container.register<IShiftRepository>("IShiftRepository", {
+    useClass: ShiftRepository,
 });

--- a/src/controllers/ChatterController.ts
+++ b/src/controllers/ChatterController.ts
@@ -1,0 +1,70 @@
+import {Request, Response} from "express";
+import {container} from "tsyringe";
+import {ChatterService} from "../business/services/ChatterService";
+
+export class ChatterController {
+    private get service(): ChatterService {
+        return container.resolve(ChatterService);
+    }
+
+    public async getAll(_req: Request, res: Response): Promise<void> {
+        try {
+            const chatters = await this.service.getAll();
+            res.json(chatters.map(c => c.toJSON()));
+        } catch (err) {
+            console.error(err);
+            res.status(500).send("Error fetching chatters");
+        }
+    }
+
+    public async getById(req: Request, res: Response): Promise<void> {
+        try {
+            const id = Number(req.params.id);
+            const chatter = await this.service.getById(id);
+            if (!chatter) {
+                res.status(404).send("Chatter not found");
+                return;
+            }
+            res.json(chatter.toJSON());
+        } catch (err) {
+            console.error(err);
+            res.status(500).send("Error fetching chatter");
+        }
+    }
+
+    public async create(req: Request, res: Response): Promise<void> {
+        try {
+            const chatter = await this.service.create(req.body);
+            res.status(201).json(chatter.toJSON());
+        } catch (err) {
+            console.error(err);
+            res.status(500).send("Error creating chatter");
+        }
+    }
+
+    public async update(req: Request, res: Response): Promise<void> {
+        try {
+            const id = Number(req.params.id);
+            const chatter = await this.service.update(id, req.body);
+            if (!chatter) {
+                res.status(404).send("Chatter not found");
+                return;
+            }
+            res.json(chatter.toJSON());
+        } catch (err) {
+            console.error(err);
+            res.status(500).send("Error updating chatter");
+        }
+    }
+
+    public async delete(req: Request, res: Response): Promise<void> {
+        try {
+            const id = Number(req.params.id);
+            await this.service.delete(id);
+            res.sendStatus(204);
+        } catch (err) {
+            console.error(err);
+            res.status(500).send("Error deleting chatter");
+        }
+    }
+}

--- a/src/controllers/EmployeeEarningController.ts
+++ b/src/controllers/EmployeeEarningController.ts
@@ -1,0 +1,70 @@
+import {Request, Response} from "express";
+import {container} from "tsyringe";
+import {EmployeeEarningService} from "../business/services/EmployeeEarningService";
+
+export class EmployeeEarningController {
+    private get service(): EmployeeEarningService {
+        return container.resolve(EmployeeEarningService);
+    }
+
+    public async getAll(_req: Request, res: Response): Promise<void> {
+        try {
+            const earnings = await this.service.getAll();
+            res.json(earnings.map(e => e.toJSON()));
+        } catch (err) {
+            console.error(err);
+            res.status(500).send("Error fetching earnings");
+        }
+    }
+
+    public async getById(req: Request, res: Response): Promise<void> {
+        try {
+            const id = Number(req.params.id);
+            const earning = await this.service.getById(id);
+            if (!earning) {
+                res.status(404).send("Earning not found");
+                return;
+            }
+            res.json(earning.toJSON());
+        } catch (err) {
+            console.error(err);
+            res.status(500).send("Error fetching earning");
+        }
+    }
+
+    public async create(req: Request, res: Response): Promise<void> {
+        try {
+            const earning = await this.service.create(req.body);
+            res.status(201).json(earning.toJSON());
+        } catch (err) {
+            console.error(err);
+            res.status(500).send("Error creating earning");
+        }
+    }
+
+    public async update(req: Request, res: Response): Promise<void> {
+        try {
+            const id = Number(req.params.id);
+            const earning = await this.service.update(id, req.body);
+            if (!earning) {
+                res.status(404).send("Earning not found");
+                return;
+            }
+            res.json(earning.toJSON());
+        } catch (err) {
+            console.error(err);
+            res.status(500).send("Error updating earning");
+        }
+    }
+
+    public async delete(req: Request, res: Response): Promise<void> {
+        try {
+            const id = Number(req.params.id);
+            await this.service.delete(id);
+            res.sendStatus(204);
+        } catch (err) {
+            console.error(err);
+            res.status(500).send("Error deleting earning");
+        }
+    }
+}

--- a/src/controllers/ShiftController.ts
+++ b/src/controllers/ShiftController.ts
@@ -1,0 +1,70 @@
+import {Request, Response} from "express";
+import {container} from "tsyringe";
+import {ShiftService} from "../business/services/ShiftService";
+
+export class ShiftController {
+    private get service(): ShiftService {
+        return container.resolve(ShiftService);
+    }
+
+    public async getAll(_req: Request, res: Response): Promise<void> {
+        try {
+            const shifts = await this.service.getAll();
+            res.json(shifts.map(s => s.toJSON()));
+        } catch (err) {
+            console.error(err);
+            res.status(500).send("Error fetching shifts");
+        }
+    }
+
+    public async getById(req: Request, res: Response): Promise<void> {
+        try {
+            const id = Number(req.params.id);
+            const shift = await this.service.getById(id);
+            if (!shift) {
+                res.status(404).send("Shift not found");
+                return;
+            }
+            res.json(shift.toJSON());
+        } catch (err) {
+            console.error(err);
+            res.status(500).send("Error fetching shift");
+        }
+    }
+
+    public async create(req: Request, res: Response): Promise<void> {
+        try {
+            const shift = await this.service.create(req.body);
+            res.status(201).json(shift.toJSON());
+        } catch (err) {
+            console.error(err);
+            res.status(500).send("Error creating shift");
+        }
+    }
+
+    public async update(req: Request, res: Response): Promise<void> {
+        try {
+            const id = Number(req.params.id);
+            const shift = await this.service.update(id, req.body);
+            if (!shift) {
+                res.status(404).send("Shift not found");
+                return;
+            }
+            res.json(shift.toJSON());
+        } catch (err) {
+            console.error(err);
+            res.status(500).send("Error updating shift");
+        }
+    }
+
+    public async delete(req: Request, res: Response): Promise<void> {
+        try {
+            const id = Number(req.params.id);
+            await this.service.delete(id);
+            res.sendStatus(204);
+        } catch (err) {
+            console.error(err);
+            res.status(500).send("Error deleting shift");
+        }
+    }
+}

--- a/src/controllers/UserController.ts
+++ b/src/controllers/UserController.ts
@@ -7,6 +7,68 @@ export class UserController {
         return container.resolve(UserService);
     }
 
+    public async getAll(_req: Request, res: Response): Promise<void> {
+        try {
+            const users = await this.service.getAll();
+            res.json(users.map(u => u.toJSON()));
+        } catch (err) {
+            console.error(err);
+            res.status(500).send("Error fetching users");
+        }
+    }
+
+    public async getById(req: Request, res: Response): Promise<void> {
+        try {
+            const id = Number(req.params.id);
+            const user = await this.service.getById(id);
+            if (!user) {
+                res.status(404).send("User not found");
+                return;
+            }
+            res.json(user.toJSON());
+        } catch (err) {
+            console.error(err);
+            res.status(500).send("Error fetching user");
+        }
+    }
+
+    public async create(req: Request, res: Response): Promise<void> {
+        try {
+            const { username, password, fullName, role } = req.body;
+            const user = await this.service.create({ username, password, fullName, role });
+            res.status(201).json(user.toJSON());
+        } catch (err) {
+            console.error(err);
+            res.status(500).send("Error creating user");
+        }
+    }
+
+    public async update(req: Request, res: Response): Promise<void> {
+        try {
+            const id = Number(req.params.id);
+            const user = await this.service.update(id, req.body);
+            if (!user) {
+                res.status(404).send("User not found");
+                return;
+            }
+            res.json(user.toJSON());
+        } catch (err) {
+            console.error(err);
+            res.status(500).send("Error updating user");
+        }
+    }
+
+    public async delete(req: Request, res: Response): Promise<void> {
+        try {
+            const id = Number(req.params.id);
+            await this.service.delete(id);
+            res.sendStatus(204);
+        } catch (err) {
+            console.error(err);
+            res.status(500).send("Error deleting user");
+        }
+    }
+
     public async login(req: Request, res: Response): Promise<void> {
         try {
             const { email, password } = req.body;

--- a/src/data/interfaces/IChatterRepository.ts
+++ b/src/data/interfaces/IChatterRepository.ts
@@ -1,0 +1,22 @@
+import {ChatterModel} from "../../business/models/ChatterModel";
+import {ChatterStatus, CurrencySymbol} from "../../rename/types";
+
+export interface IChatterRepository {
+    findAll(): Promise<ChatterModel[]>;
+    findById(id: number): Promise<ChatterModel | null>;
+    create(data: {
+        email: string;
+        currency: CurrencySymbol;
+        commissionRate: number;
+        platformFee: number;
+        status: ChatterStatus;
+    }): Promise<ChatterModel>;
+    update(id: number, data: {
+        email?: string;
+        currency?: CurrencySymbol;
+        commissionRate?: number;
+        platformFee?: number;
+        status?: ChatterStatus;
+    }): Promise<ChatterModel | null>;
+    delete(id: number): Promise<void>;
+}

--- a/src/data/interfaces/IEmployeeEarningRepository.ts
+++ b/src/data/interfaces/IEmployeeEarningRepository.ts
@@ -1,0 +1,19 @@
+import {EmployeeEarningModel} from "../../business/models/EmployeeEarningModel";
+
+export interface IEmployeeEarningRepository {
+    findAll(): Promise<EmployeeEarningModel[]>;
+    findById(id: number): Promise<EmployeeEarningModel | null>;
+    create(data: {
+        chatterId: number;
+        date: Date;
+        amount: number;
+        description?: string | null;
+    }): Promise<EmployeeEarningModel>;
+    update(id: number, data: {
+        chatterId?: number;
+        date?: Date;
+        amount?: number;
+        description?: string | null;
+    }): Promise<EmployeeEarningModel | null>;
+    delete(id: number): Promise<void>;
+}

--- a/src/data/interfaces/IShiftRepository.ts
+++ b/src/data/interfaces/IShiftRepository.ts
@@ -1,0 +1,22 @@
+import {ShiftModel} from "../../business/models/ShiftModel";
+import {ShiftStatus} from "../../rename/types";
+
+export interface IShiftRepository {
+    findAll(): Promise<ShiftModel[]>;
+    findById(id: number): Promise<ShiftModel | null>;
+    create(data: {
+        chatterId: number;
+        date: Date;
+        startTime: Date;
+        endTime: Date;
+        status: ShiftStatus;
+    }): Promise<ShiftModel>;
+    update(id: number, data: {
+        chatterId?: number;
+        date?: Date;
+        startTime?: Date;
+        endTime?: Date;
+        status?: ShiftStatus;
+    }): Promise<ShiftModel | null>;
+    delete(id: number): Promise<void>;
+}

--- a/src/data/interfaces/IUserRepository.ts
+++ b/src/data/interfaces/IUserRepository.ts
@@ -1,5 +1,21 @@
 import {UserModel} from "../../business/models/UserModel";
+import {Role} from "../../rename/types";
 
 export interface IUserRepository {
+    findAll(): Promise<UserModel[]>;
+    findById(id: number): Promise<UserModel | null>;
     findByEmail(email: string): Promise<UserModel | null>;
+    create(data: {
+        username: string;
+        passwordHash: string;
+        fullName: string;
+        role: Role;
+    }): Promise<UserModel>;
+    update(id: number, data: {
+        username?: string;
+        passwordHash?: string;
+        fullName?: string;
+        role?: Role;
+    }): Promise<UserModel | null>;
+    delete(id: number): Promise<void>;
 }

--- a/src/data/repositories/ChatterRepository.ts
+++ b/src/data/repositories/ChatterRepository.ts
@@ -1,0 +1,58 @@
+import {BaseRepository} from "./BaseRepository";
+import {IChatterRepository} from "../interfaces/IChatterRepository";
+import {ChatterModel} from "../../business/models/ChatterModel";
+import {ChatterStatus, CurrencySymbol} from "../../rename/types";
+import {ResultSetHeader, RowDataPacket} from "mysql2";
+
+export class ChatterRepository extends BaseRepository implements IChatterRepository {
+    public async findAll(): Promise<ChatterModel[]> {
+        const rows = await this.execute<RowDataPacket[]>(
+            "SELECT id, email, currency, commission_rate, platform_fee, status, created_at FROM chatters",
+            []
+        );
+        return rows.map(ChatterModel.fromRow);
+    }
+
+    public async findById(id: number): Promise<ChatterModel | null> {
+        const rows = await this.execute<RowDataPacket[]>(
+            "SELECT id, email, currency, commission_rate, platform_fee, status, created_at FROM chatters WHERE id = ?",
+            [id]
+        );
+        return rows.length ? ChatterModel.fromRow(rows[0]) : null;
+    }
+
+    public async create(data: { email: string; currency: CurrencySymbol; commissionRate: number; platformFee: number; status: ChatterStatus; }): Promise<ChatterModel> {
+        const result = await this.execute<ResultSetHeader>(
+            "INSERT INTO chatters (email, currency, commission_rate, platform_fee, status) VALUES (?, ?, ?, ?, ?)",
+            [data.email, data.currency, data.commissionRate, data.platformFee, data.status]
+        );
+        const insertedId = Number(result.insertId);
+        const created = await this.findById(insertedId);
+        if (!created) throw new Error("Failed to fetch created chatter");
+        return created;
+    }
+
+    public async update(id: number, data: { email?: string; currency?: CurrencySymbol; commissionRate?: number; platformFee?: number; status?: ChatterStatus; }): Promise<ChatterModel | null> {
+        const existing = await this.findById(id);
+        if (!existing) return null;
+        await this.execute<ResultSetHeader>(
+            "UPDATE chatters SET email = ?, currency = ?, commission_rate = ?, platform_fee = ?, status = ? WHERE id = ?",
+            [
+                data.email ?? existing.email,
+                data.currency ?? existing.currency,
+                data.commissionRate ?? existing.commissionRate,
+                data.platformFee ?? existing.platformFee,
+                data.status ?? existing.status,
+                id
+            ]
+        );
+        return this.findById(id);
+    }
+
+    public async delete(id: number): Promise<void> {
+        await this.execute<ResultSetHeader>(
+            "DELETE FROM chatters WHERE id = ?",
+            [id]
+        );
+    }
+}

--- a/src/data/repositories/EmployeeEarningRepository.ts
+++ b/src/data/repositories/EmployeeEarningRepository.ts
@@ -1,0 +1,56 @@
+import {BaseRepository} from "./BaseRepository";
+import {IEmployeeEarningRepository} from "../interfaces/IEmployeeEarningRepository";
+import {EmployeeEarningModel} from "../../business/models/EmployeeEarningModel";
+import {ResultSetHeader, RowDataPacket} from "mysql2";
+
+export class EmployeeEarningRepository extends BaseRepository implements IEmployeeEarningRepository {
+    public async findAll(): Promise<EmployeeEarningModel[]> {
+        const rows = await this.execute<RowDataPacket[]>(
+            "SELECT id, chatter_id, date, amount, description, created_at FROM employee_earnings",
+            []
+        );
+        return rows.map(EmployeeEarningModel.fromRow);
+    }
+
+    public async findById(id: number): Promise<EmployeeEarningModel | null> {
+        const rows = await this.execute<RowDataPacket[]>(
+            "SELECT id, chatter_id, date, amount, description, created_at FROM employee_earnings WHERE id = ?",
+            [id]
+        );
+        return rows.length ? EmployeeEarningModel.fromRow(rows[0]) : null;
+    }
+
+    public async create(data: { chatterId: number; date: Date; amount: number; description?: string | null; }): Promise<EmployeeEarningModel> {
+        const result = await this.execute<ResultSetHeader>(
+            "INSERT INTO employee_earnings (chatter_id, date, amount, description) VALUES (?, ?, ?, ?)",
+            [data.chatterId, data.date, data.amount, data.description ?? null]
+        );
+        const insertedId = Number(result.insertId);
+        const created = await this.findById(insertedId);
+        if (!created) throw new Error("Failed to fetch created earning");
+        return created;
+    }
+
+    public async update(id: number, data: { chatterId?: number; date?: Date; amount?: number; description?: string | null; }): Promise<EmployeeEarningModel | null> {
+        const existing = await this.findById(id);
+        if (!existing) return null;
+        await this.execute<ResultSetHeader>(
+            "UPDATE employee_earnings SET chatter_id = ?, date = ?, amount = ?, description = ? WHERE id = ?",
+            [
+                data.chatterId ?? existing.chatterId,
+                data.date ?? existing.date,
+                data.amount ?? existing.amount,
+                data.description ?? existing.description,
+                id
+            ]
+        );
+        return this.findById(id);
+    }
+
+    public async delete(id: number): Promise<void> {
+        await this.execute<ResultSetHeader>(
+            "DELETE FROM employee_earnings WHERE id = ?",
+            [id]
+        );
+    }
+}

--- a/src/data/repositories/ShiftRepository.ts
+++ b/src/data/repositories/ShiftRepository.ts
@@ -1,0 +1,58 @@
+import {BaseRepository} from "./BaseRepository";
+import {IShiftRepository} from "../interfaces/IShiftRepository";
+import {ShiftModel} from "../../business/models/ShiftModel";
+import {ShiftStatus} from "../../rename/types";
+import {ResultSetHeader, RowDataPacket} from "mysql2";
+
+export class ShiftRepository extends BaseRepository implements IShiftRepository {
+    public async findAll(): Promise<ShiftModel[]> {
+        const rows = await this.execute<RowDataPacket[]>(
+            "SELECT id, chatter_id, date, start_time, end_time, status, created_at FROM shifts",
+            []
+        );
+        return rows.map(ShiftModel.fromRow);
+    }
+
+    public async findById(id: number): Promise<ShiftModel | null> {
+        const rows = await this.execute<RowDataPacket[]>(
+            "SELECT id, chatter_id, date, start_time, end_time, status, created_at FROM shifts WHERE id = ?",
+            [id]
+        );
+        return rows.length ? ShiftModel.fromRow(rows[0]) : null;
+    }
+
+    public async create(data: { chatterId: number; date: Date; startTime: Date; endTime: Date; status: ShiftStatus; }): Promise<ShiftModel> {
+        const result = await this.execute<ResultSetHeader>(
+            "INSERT INTO shifts (chatter_id, date, start_time, end_time, status) VALUES (?, ?, ?, ?, ?)",
+            [data.chatterId, data.date, data.startTime, data.endTime, data.status]
+        );
+        const insertedId = Number(result.insertId);
+        const created = await this.findById(insertedId);
+        if (!created) throw new Error("Failed to fetch created shift");
+        return created;
+    }
+
+    public async update(id: number, data: { chatterId?: number; date?: Date; startTime?: Date; endTime?: Date; status?: ShiftStatus; }): Promise<ShiftModel | null> {
+        const existing = await this.findById(id);
+        if (!existing) return null;
+        await this.execute<ResultSetHeader>(
+            "UPDATE shifts SET chatter_id = ?, date = ?, start_time = ?, end_time = ?, status = ? WHERE id = ?",
+            [
+                data.chatterId ?? existing.chatterId,
+                data.date ?? existing.date,
+                data.startTime ?? existing.startTime,
+                data.endTime ?? existing.endTime,
+                data.status ?? existing.status,
+                id
+            ]
+        );
+        return this.findById(id);
+    }
+
+    public async delete(id: number): Promise<void> {
+        await this.execute<ResultSetHeader>(
+            "DELETE FROM shifts WHERE id = ?",
+            [id]
+        );
+    }
+}

--- a/src/data/repositories/UserRepository.ts
+++ b/src/data/repositories/UserRepository.ts
@@ -1,25 +1,65 @@
 import {BaseRepository} from "./BaseRepository";
 import {IUserRepository} from "../interfaces/IUserRepository";
 import {UserModel} from "../../business/models/UserModel";
-import { ResultSetHeader, RowDataPacket } from "mysql2";
+import {Role} from "../../rename/types";
+import {ResultSetHeader, RowDataPacket} from "mysql2";
 
 export class UserRepository extends BaseRepository implements IUserRepository {
+    public async findAll(): Promise<UserModel[]> {
+        const rows = await this.execute<RowDataPacket[]>(
+            "SELECT id, username, password_hash, full_name, role, created_at FROM users",
+            []
+        );
+        return rows.map(UserModel.fromRow);
+    }
+
+    public async findById(id: number): Promise<UserModel | null> {
+        const rows = await this.execute<RowDataPacket[]>(
+            "SELECT id, username, password_hash, full_name, role, created_at FROM users WHERE id = ?",
+            [id]
+        );
+        return rows.length ? UserModel.fromRow(rows[0]) : null;
+    }
+
     public async findByEmail(email: string): Promise<UserModel | null> {
-        const query = `
-            SELECT id, company_id, email, password_hash, role, created_at
-            FROM users
-            WHERE email = $1
-        `;
-        const result = await this.execute<RowDataPacket[]>(query, [email]);
-        if (result.length === 0) {
-            return null;
-        }
-        const row = result[0];
-        return new UserModel(
-            row.id,
-            row.name,
-            row.email,
-            row.password
+        const rows = await this.execute<RowDataPacket[]>(
+            "SELECT id, username, password_hash, full_name, role, created_at FROM users WHERE username = ?",
+            [email]
+        );
+        return rows.length ? UserModel.fromRow(rows[0]) : null;
+    }
+
+    public async create(data: { username: string; passwordHash: string; fullName: string; role: Role; }): Promise<UserModel> {
+        const result = await this.execute<ResultSetHeader>(
+            "INSERT INTO users (username, password_hash, full_name, role) VALUES (?, ?, ?, ?)",
+            [data.username, data.passwordHash, data.fullName, data.role]
+        );
+        const insertedId = Number(result.insertId);
+        const created = await this.findById(insertedId);
+        if (!created) throw new Error("Failed to fetch created user");
+        return created;
+    }
+
+    public async update(id: number, data: { username?: string; passwordHash?: string; fullName?: string; role?: Role; }): Promise<UserModel | null> {
+        const existing = await this.findById(id);
+        if (!existing) return null;
+        await this.execute<ResultSetHeader>(
+            "UPDATE users SET username = ?, password_hash = ?, full_name = ?, role = ? WHERE id = ?",
+            [
+                data.username ?? existing.username,
+                data.passwordHash ?? existing.passwordHash,
+                data.fullName ?? existing.fullName,
+                data.role ?? existing.role,
+                id
+            ]
+        );
+        return this.findById(id);
+    }
+
+    public async delete(id: number): Promise<void> {
+        await this.execute<ResultSetHeader>(
+            "DELETE FROM users WHERE id = ?",
+            [id]
         );
     }
 }

--- a/src/routes/ChatterRoute.ts
+++ b/src/routes/ChatterRoute.ts
@@ -1,11 +1,10 @@
-import { Router } from "express";
-import { authenticateToken } from "../middleware/auth";
-import {UserController} from "../controllers/UserController";
+import {Router} from "express";
+import {authenticateToken} from "../middleware/auth";
+import {ChatterController} from "../controllers/ChatterController";
 
 const router = Router();
-const controller = new UserController();
+const controller = new ChatterController();
 
-router.post("/login", controller.login.bind(controller));
 router.get("/", authenticateToken, controller.getAll.bind(controller));
 router.get("/:id", authenticateToken, controller.getById.bind(controller));
 router.post("/", authenticateToken, controller.create.bind(controller));

--- a/src/routes/EmployeeEarningRoute.ts
+++ b/src/routes/EmployeeEarningRoute.ts
@@ -1,11 +1,10 @@
-import { Router } from "express";
-import { authenticateToken } from "../middleware/auth";
-import {UserController} from "../controllers/UserController";
+import {Router} from "express";
+import {authenticateToken} from "../middleware/auth";
+import {EmployeeEarningController} from "../controllers/EmployeeEarningController";
 
 const router = Router();
-const controller = new UserController();
+const controller = new EmployeeEarningController();
 
-router.post("/login", controller.login.bind(controller));
 router.get("/", authenticateToken, controller.getAll.bind(controller));
 router.get("/:id", authenticateToken, controller.getById.bind(controller));
 router.post("/", authenticateToken, controller.create.bind(controller));

--- a/src/routes/ShiftRoute.ts
+++ b/src/routes/ShiftRoute.ts
@@ -1,11 +1,10 @@
-import { Router } from "express";
-import { authenticateToken } from "../middleware/auth";
-import {UserController} from "../controllers/UserController";
+import {Router} from "express";
+import {authenticateToken} from "../middleware/auth";
+import {ShiftController} from "../controllers/ShiftController";
 
 const router = Router();
-const controller = new UserController();
+const controller = new ShiftController();
 
-router.post("/login", controller.login.bind(controller));
 router.get("/", authenticateToken, controller.getAll.bind(controller));
 router.get("/:id", authenticateToken, controller.getById.bind(controller));
 router.post("/", authenticateToken, controller.create.bind(controller));

--- a/src/server.ts
+++ b/src/server.ts
@@ -3,6 +3,10 @@ import express from "express";
 import cors from "cors";
 import { createServer } from "http";
 import userRoute from "./routes/UserRoute";
+import chatterRoute from "./routes/ChatterRoute";
+import employeeEarningRoute from "./routes/EmployeeEarningRoute";
+import shiftRoute from "./routes/ShiftRoute";
+import "./container";
 
 const app = express();
 
@@ -12,10 +16,13 @@ app.use(cors({
     allowedHeaders: ["Content-Type","Authorization"]
 }));
 
-app.use('api/user', userRoute);
-
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
+
+app.use("/api/users", userRoute);
+app.use("/api/chatters", chatterRoute);
+app.use("/api/employee-earnings", employeeEarningRoute);
+app.use("/api/shifts", shiftRoute);
 
 const server = createServer(app);
 


### PR DESCRIPTION
## Summary
- add CRUD operations to User service/controller/repository
- implement repository, service, controller and routes for Chatters, Employee earnings and Shifts
- wire new modules into DI container and server routing

## Testing
- `npm run lint` *(fails: ESLint couldn't find configuration)*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68adb88361448327a335b05900d2c02a