### PR TITLE
feat: add commission persistence

### DIFF
--- a/src/business/models/CommissionModel.ts
+++ b/src/business/models/CommissionModel.ts
@@ -1,0 +1,55 @@
+import { CommissionStatus } from "../../rename/types";
+
+export class CommissionModel {
+    constructor(
+        private _id: number,
+        private _chatterId: number,
+        private _periodStart: Date,
+        private _periodEnd: Date,
+        private _earnings: number,
+        private _commissionRate: number,
+        private _commission: number,
+        private _status: CommissionStatus,
+        private _createdAt: Date,
+    ) {}
+
+    public toJSON(): Record<string, any> {
+        return {
+            id: this.id,
+            chatterId: this.chatterId,
+            periodStart: this.periodStart,
+            periodEnd: this.periodEnd,
+            earnings: this.earnings,
+            commissionRate: this.commissionRate,
+            commission: this.commission,
+            status: this.status,
+            createdAt: this.createdAt,
+        };
+    }
+
+    // Getters
+    get id(): number { return this._id; }
+    get chatterId(): number { return this._chatterId; }
+    get periodStart(): Date { return this._periodStart; }
+    get periodEnd(): Date { return this._periodEnd; }
+    get earnings(): number { return this._earnings; }
+    get commissionRate(): number { return this._commissionRate; }
+    get commission(): number { return this._commission; }
+    get status(): CommissionStatus { return this._status; }
+    get createdAt(): Date { return this._createdAt; }
+
+    static fromRow(r: any): CommissionModel {
+        return new CommissionModel(
+            Number(r.id),
+            Number(r.chatter_id),
+            new Date(r.period_start),
+            new Date(r.period_end),
+            Number(r.earnings),
+            Number(r.commission_rate),
+            Number(r.commission),
+            (r.status ?? "pending") as CommissionStatus,
+            new Date(r.created_at),
+        );
+    }
+}
+

--- a/src/business/services/CommissionService.ts
+++ b/src/business/services/CommissionService.ts
@@ -1,0 +1,47 @@
+import { inject, injectable } from "tsyringe";
+import { ICommissionRepository } from "../../data/interfaces/ICommissionRepository";
+import { CommissionModel } from "../models/CommissionModel";
+import { CommissionStatus } from "../../rename/types";
+
+@injectable()
+export class CommissionService {
+    constructor(
+        @inject("ICommissionRepository") private commissionRepo: ICommissionRepository
+    ) {}
+
+    public async getAll(): Promise<CommissionModel[]> {
+        return this.commissionRepo.findAll();
+    }
+
+    public async getById(id: number): Promise<CommissionModel | null> {
+        return this.commissionRepo.findById(id);
+    }
+
+    public async create(data: {
+        chatterId: number;
+        periodStart: Date;
+        periodEnd: Date;
+        earnings: number;
+        commissionRate: number;
+        commission: number;
+        status: CommissionStatus;
+    }): Promise<CommissionModel> {
+        return this.commissionRepo.create(data);
+    }
+
+    public async update(id: number, data: {
+        chatterId?: number;
+        periodStart?: Date;
+        periodEnd?: Date;
+        earnings?: number;
+        commissionRate?: number;
+        commission?: number;
+        status?: CommissionStatus;
+    }): Promise<CommissionModel | null> {
+        return this.commissionRepo.update(id, data);
+    }
+
+    public async delete(id: number): Promise<void> {
+        await this.commissionRepo.delete(id);
+    }
+}

--- a/src/container/index.ts
+++ b/src/container/index.ts
@@ -11,6 +11,9 @@ import {EmployeeEarningRepository} from "../data/repositories/EmployeeEarningRep
 import {ShiftService} from "../business/services/ShiftService";
 import {IShiftRepository} from "../data/interfaces/IShiftRepository";
 import {ShiftRepository} from "../data/repositories/ShiftRepository";
+import {CommissionService} from "../business/services/CommissionService";
+import {ICommissionRepository} from "../data/interfaces/ICommissionRepository";
+import {CommissionRepository} from "../data/repositories/CommissionRepository";
 
 container.register("UserService", { useClass: UserService });
 
@@ -31,4 +34,9 @@ container.register<IEmployeeEarningRepository>("IEmployeeEarningRepository", {
 container.register("ShiftService", { useClass: ShiftService });
 container.register<IShiftRepository>("IShiftRepository", {
     useClass: ShiftRepository,
+});
+
+container.register("CommissionService", { useClass: CommissionService });
+container.register<ICommissionRepository>("ICommissionRepository", {
+    useClass: CommissionRepository,
 });

--- a/src/controllers/CommissionController.ts
+++ b/src/controllers/CommissionController.ts
@@ -1,0 +1,70 @@
+import { Request, Response } from "express";
+import { container } from "tsyringe";
+import { CommissionService } from "../business/services/CommissionService";
+
+export class CommissionController {
+    private get service(): CommissionService {
+        return container.resolve(CommissionService);
+    }
+
+    public async getAll(_req: Request, res: Response): Promise<void> {
+        try {
+            const commissions = await this.service.getAll();
+            res.json(commissions.map(c => c.toJSON()));
+        } catch (err) {
+            console.error(err);
+            res.status(500).send("Error fetching commissions");
+        }
+    }
+
+    public async getById(req: Request, res: Response): Promise<void> {
+        try {
+            const id = Number(req.params.id);
+            const commission = await this.service.getById(id);
+            if (!commission) {
+                res.status(404).send("Commission not found");
+                return;
+            }
+            res.json(commission.toJSON());
+        } catch (err) {
+            console.error(err);
+            res.status(500).send("Error fetching commission");
+        }
+    }
+
+    public async create(req: Request, res: Response): Promise<void> {
+        try {
+            const commission = await this.service.create(req.body);
+            res.status(201).json(commission.toJSON());
+        } catch (err) {
+            console.error(err);
+            res.status(500).send("Error creating commission");
+        }
+    }
+
+    public async update(req: Request, res: Response): Promise<void> {
+        try {
+            const id = Number(req.params.id);
+            const commission = await this.service.update(id, req.body);
+            if (!commission) {
+                res.status(404).send("Commission not found");
+                return;
+            }
+            res.json(commission.toJSON());
+        } catch (err) {
+            console.error(err);
+            res.status(500).send("Error updating commission");
+        }
+    }
+
+    public async delete(req: Request, res: Response): Promise<void> {
+        try {
+            const id = Number(req.params.id);
+            await this.service.delete(id);
+            res.sendStatus(204);
+        } catch (err) {
+            console.error(err);
+            res.status(500).send("Error deleting commission");
+        }
+    }
+}

--- a/src/data/interfaces/ICommissionRepository.ts
+++ b/src/data/interfaces/ICommissionRepository.ts
@@ -1,0 +1,26 @@
+import { CommissionModel } from "../../business/models/CommissionModel";
+import { CommissionStatus } from "../../rename/types";
+
+export interface ICommissionRepository {
+    findAll(): Promise<CommissionModel[]>;
+    findById(id: number): Promise<CommissionModel | null>;
+    create(data: {
+        chatterId: number;
+        periodStart: Date;
+        periodEnd: Date;
+        earnings: number;
+        commissionRate: number;
+        commission: number;
+        status: CommissionStatus;
+    }): Promise<CommissionModel>;
+    update(id: number, data: {
+        chatterId?: number;
+        periodStart?: Date;
+        periodEnd?: Date;
+        earnings?: number;
+        commissionRate?: number;
+        commission?: number;
+        status?: CommissionStatus;
+    }): Promise<CommissionModel | null>;
+    delete(id: number): Promise<void>;
+}

--- a/src/data/repositories/CommissionRepository.ts
+++ b/src/data/repositories/CommissionRepository.ts
@@ -1,0 +1,76 @@
+import { BaseRepository } from "./BaseRepository";
+import { ICommissionRepository } from "../interfaces/ICommissionRepository";
+import { CommissionModel } from "../../business/models/CommissionModel";
+import { CommissionStatus } from "../../rename/types";
+import { ResultSetHeader, RowDataPacket } from "mysql2";
+
+export class CommissionRepository extends BaseRepository implements ICommissionRepository {
+    public async findAll(): Promise<CommissionModel[]> {
+        const rows = await this.execute<RowDataPacket[]>(
+            "SELECT id, chatter_id, period_start, period_end, earnings, commission_rate, commission, status, created_at FROM commissions",
+            []
+        );
+        return rows.map(CommissionModel.fromRow);
+    }
+
+    public async findById(id: number): Promise<CommissionModel | null> {
+        const rows = await this.execute<RowDataPacket[]>(
+            "SELECT id, chatter_id, period_start, period_end, earnings, commission_rate, commission, status, created_at FROM commissions WHERE id = ?",
+            [id]
+        );
+        return rows.length ? CommissionModel.fromRow(rows[0]) : null;
+    }
+
+    public async create(data: {
+        chatterId: number;
+        periodStart: Date;
+        periodEnd: Date;
+        earnings: number;
+        commissionRate: number;
+        commission: number;
+        status: CommissionStatus;
+    }): Promise<CommissionModel> {
+        const result = await this.execute<ResultSetHeader>(
+            "INSERT INTO commissions (chatter_id, period_start, period_end, earnings, commission_rate, commission, status) VALUES (?, ?, ?, ?, ?, ?, ?)",
+            [data.chatterId, data.periodStart, data.periodEnd, data.earnings, data.commissionRate, data.commission, data.status]
+        );
+        const insertedId = Number(result.insertId);
+        const created = await this.findById(insertedId);
+        if (!created) throw new Error("Failed to fetch created commission");
+        return created;
+    }
+
+    public async update(id: number, data: {
+        chatterId?: number;
+        periodStart?: Date;
+        periodEnd?: Date;
+        earnings?: number;
+        commissionRate?: number;
+        commission?: number;
+        status?: CommissionStatus;
+    }): Promise<CommissionModel | null> {
+        const existing = await this.findById(id);
+        if (!existing) return null;
+        await this.execute<ResultSetHeader>(
+            "UPDATE commissions SET chatter_id = ?, period_start = ?, period_end = ?, earnings = ?, commission_rate = ?, commission = ?, status = ? WHERE id = ?",
+            [
+                data.chatterId ?? existing.chatterId,
+                data.periodStart ?? existing.periodStart,
+                data.periodEnd ?? existing.periodEnd,
+                data.earnings ?? existing.earnings,
+                data.commissionRate ?? existing.commissionRate,
+                data.commission ?? existing.commission,
+                data.status ?? existing.status,
+                id,
+            ]
+        );
+        return this.findById(id);
+    }
+
+    public async delete(id: number): Promise<void> {
+        await this.execute<ResultSetHeader>(
+            "DELETE FROM commissions WHERE id = ?",
+            [id]
+        );
+    }
+}

--- a/src/rename/types.ts
+++ b/src/rename/types.ts
@@ -2,3 +2,4 @@ export type Role = "manager" | "chatter";
 export type CurrencySymbol = "€";
 export type ChatterStatus = "active" | "inactive"; // extend if you add more states
 export type ShiftStatus = "scheduled" | "active" | "completed" | "cancelled";
+export type CommissionStatus = "pending" | "paid" | "cancelled";

--- a/src/routes/CommissionRoute.ts
+++ b/src/routes/CommissionRoute.ts
@@ -1,0 +1,14 @@
+import { Router } from "express";
+import { authenticateToken } from "../middleware/auth";
+import { CommissionController } from "../controllers/CommissionController";
+
+const router = Router();
+const controller = new CommissionController();
+
+router.get("/", authenticateToken, controller.getAll.bind(controller));
+router.get("/:id", authenticateToken, controller.getById.bind(controller));
+router.post("/", authenticateToken, controller.create.bind(controller));
+router.put("/:id", authenticateToken, controller.update.bind(controller));
+router.delete("/:id", authenticateToken, controller.delete.bind(controller));
+
+export default router;

--- a/src/server.ts
+++ b/src/server.ts
@@ -6,6 +6,7 @@ import userRoute from "./routes/UserRoute";
 import chatterRoute from "./routes/ChatterRoute";
 import employeeEarningRoute from "./routes/EmployeeEarningRoute";
 import shiftRoute from "./routes/ShiftRoute";
+import commissionRoute from "./routes/CommissionRoute";
 import "./container";
 
 const app = express();
@@ -23,6 +24,7 @@ app.use("/api/users", userRoute);
 app.use("/api/chatters", chatterRoute);
 app.use("/api/employee-earnings", employeeEarningRoute);
 app.use("/api/shifts", shiftRoute);
+app.use("/api/commissions", commissionRoute);
 
 const server = createServer(app);
 


### PR DESCRIPTION
## Summary
- define CommissionStatus and model
- persist commissions with repository and service
- expose commission controller and route

## Testing
- `npm run build`
- `npm run lint` *(fails: ESLint couldn't find config file)*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68adf29daf7483278231ff3efc77f8d1