### PR TITLE
feat: add clock in/out endpoints

### DIFF
--- a/src/business/models/ShiftModel.ts
+++ b/src/business/models/ShiftModel.ts
@@ -6,7 +6,7 @@ export class ShiftModel {
         private _chatterId: number,
         private _date: Date,         // business date
         private _startTime: Date,    // datetime
-        private _endTime: Date,      // datetime
+        private _endTime: Date | null,      // datetime
         private _status: ShiftStatus,
         private _createdAt: Date,
     ) {}
@@ -28,7 +28,7 @@ export class ShiftModel {
     get chatterId(): number { return this._chatterId; }
     get date(): Date { return this._date; }
     get startTime(): Date { return this._startTime; }
-    get endTime(): Date { return this._endTime; }
+    get endTime(): Date | null { return this._endTime; }
     get status(): ShiftStatus { return this._status; }
     get createdAt(): Date { return this._createdAt; }
 
@@ -38,7 +38,7 @@ export class ShiftModel {
             Number(r.chatter_id),
             new Date(r.date),
             new Date(r.start_time),
-            new Date(r.end_time),
+            r.end_time ? new Date(r.end_time) : null,
             r.status as ShiftStatus,
             new Date(r.created_at),
         );

--- a/src/business/services/ShiftService.ts
+++ b/src/business/services/ShiftService.ts
@@ -17,12 +17,31 @@ export class ShiftService {
         return this.shiftRepo.findById(id);
     }
 
-    public async create(data: { chatterId: number; date: Date; start_time: Date; end_time: Date; status: ShiftStatus; }): Promise<ShiftModel> {
+    public async create(data: { chatterId: number; date: Date; start_time: Date; end_time?: Date | null; status: ShiftStatus; }): Promise<ShiftModel> {
         return this.shiftRepo.create(data);
     }
 
-    public async update(id: number, data: { chatterId?: number; date?: Date; start_time?: Date; end_time?: Date; status?: ShiftStatus; }): Promise<ShiftModel | null> {
+    public async update(id: number, data: { chatterId?: number; date?: Date; start_time?: Date; end_time?: Date | null; status?: ShiftStatus; }): Promise<ShiftModel | null> {
         return this.shiftRepo.update(id, data);
+    }
+
+    public async clockIn(chatterId: number): Promise<ShiftModel> {
+        const now = new Date();
+        return this.shiftRepo.create({
+            chatterId,
+            date: now,
+            start_time: now,
+            end_time: null,
+            status: "active",
+        });
+    }
+
+    public async clockOut(id: number): Promise<ShiftModel | null> {
+        const now = new Date();
+        return this.shiftRepo.update(id, {
+            end_time: now,
+            status: "completed",
+        });
     }
 
     public async delete(id: number): Promise<void> {

--- a/src/controllers/ShiftController.ts
+++ b/src/controllers/ShiftController.ts
@@ -42,6 +42,32 @@ export class ShiftController {
         }
     }
 
+    public async clockIn(req: Request, res: Response): Promise<void> {
+        try {
+            const {chatterId} = req.body;
+            const shift = await this.service.clockIn(Number(chatterId));
+            res.status(201).json(shift.toJSON());
+        } catch (err) {
+            console.error(err);
+            res.status(500).send("Error clocking in");
+        }
+    }
+
+    public async clockOut(req: Request, res: Response): Promise<void> {
+        try {
+            const id = Number(req.params.id);
+            const shift = await this.service.clockOut(id);
+            if (!shift) {
+                res.status(404).send("Shift not found");
+                return;
+            }
+            res.json(shift.toJSON());
+        } catch (err) {
+            console.error(err);
+            res.status(500).send("Error clocking out");
+        }
+    }
+
     public async update(req: Request, res: Response): Promise<void> {
         try {
             const id = Number(req.params.id);

--- a/src/data/interfaces/IShiftRepository.ts
+++ b/src/data/interfaces/IShiftRepository.ts
@@ -8,14 +8,14 @@ export interface IShiftRepository {
         chatterId: number;
         date: Date;
         start_time: Date;
-        end_time: Date;
+        end_time?: Date | null;
         status: ShiftStatus;
     }): Promise<ShiftModel>;
     update(id: number, data: {
         chatterId?: number;
         date?: Date;
         start_time?: Date;
-        end_time?: Date;
+        end_time?: Date | null;
         status?: ShiftStatus;
     }): Promise<ShiftModel | null>;
     delete(id: number): Promise<void>;

--- a/src/data/repositories/ShiftRepository.ts
+++ b/src/data/repositories/ShiftRepository.ts
@@ -21,10 +21,10 @@ export class ShiftRepository extends BaseRepository implements IShiftRepository 
         return rows.length ? ShiftModel.fromRow(rows[0]) : null;
     }
 
-    public async create(data: { chatterId: number; date: Date; start_time: Date; end_time: Date; status: ShiftStatus; }): Promise<ShiftModel> {
+    public async create(data: { chatterId: number; date: Date; start_time: Date; end_time?: Date | null; status: ShiftStatus; }): Promise<ShiftModel> {
         const result = await this.execute<ResultSetHeader>(
             "INSERT INTO shifts (chatter_id, date, start_time, end_time, status) VALUES (?, ?, ?, ?, ?)",
-            [data.chatterId, new Date(), data.start_time, data.end_time, data.status]
+            [data.chatterId, data.date, data.start_time, data.end_time ?? null, data.status]
         );
         const insertedId = Number(result.insertId);
         const created = await this.findById(insertedId);
@@ -32,7 +32,7 @@ export class ShiftRepository extends BaseRepository implements IShiftRepository 
         return created;
     }
 
-    public async update(id: number, data: { chatterId?: number; date?: Date; start_time?: Date; end_time?: Date; status?: ShiftStatus; }): Promise<ShiftModel | null> {
+    public async update(id: number, data: { chatterId?: number; date?: Date; start_time?: Date; end_time?: Date | null; status?: ShiftStatus; }): Promise<ShiftModel | null> {
         const existing = await this.findById(id);
         if (!existing) return null;
         await this.execute<ResultSetHeader>(

--- a/src/routes/ShiftRoute.ts
+++ b/src/routes/ShiftRoute.ts
@@ -10,5 +10,7 @@ router.get("/:id", authenticateToken, controller.getById.bind(controller));
 router.post("/", authenticateToken, controller.create.bind(controller));
 router.put("/:id", authenticateToken, controller.update.bind(controller));
 router.delete("/:id", authenticateToken, controller.delete.bind(controller));
+router.post("/clock-in", authenticateToken, controller.clockIn.bind(controller));
+router.post("/:id/clock-out", authenticateToken, controller.clockOut.bind(controller));
 
 export default router;


### PR DESCRIPTION
## Summary
- allow ShiftModel to store unfinished shifts
- expose service and controller methods for clock in and clock out
- add REST routes for clocking in and out

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ae02daf618832792af87b225c844be