### PR TITLE
feat: allow dashboard subdomains

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -23,10 +23,9 @@ const corsOptions: cors.CorsOptions = {
 
         let ok = allowList.has(origin);
         if (!ok) {
-            // optionally allow *.vercel.app
             try {
                 const host = new URL(origin).hostname;
-                ok = host.endsWith(".vercel.app");
+                ok = host.endsWith("dashboardilgd.com") || host.endsWith(".vercel.app");
             } catch {}
         }
         return ok ? cb(null, true) : cb(new Error("Not allowed by CORS"));


### PR DESCRIPTION
## Summary
- broaden CORS origin check to allow any dashboardilgd.com subdomain

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: ESLint couldn't find config)*
- `curl -i -X OPTIONS http://localhost:3002/api/users/login -H "Origin: https://www.dashboardilgd.com" -H "Access-Control-Request-Method: POST" -H "Access-Control-Request-Headers: Content-Type"`
- `curl -i -X POST http://localhost:3002/api/users/login -H "Origin: https://www.dashboardilgd.com" -H "Content-Type: application/json" -d '{"email":"test@example.com","password":"123"}'`


------
https://chatgpt.com/codex/tasks/task_e_68b03eb9e28883278ad4f818428a4f43