### PR TITLE
Initialize DI container before loading routes

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -4,5 +4,12 @@
       "memory": 512,
       "maxDuration": 10
     }
-  }
+  },
+  "routes": [
+    {
+      "src": "/api/(.*)",
+      "dest": "/api/$1",
+      "methods": ["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"]
+    }
+  ]
 }


### PR DESCRIPTION
## Summary
- ensure dependency registrations execute before routes by importing container setup in `app.ts`
- broaden CORS allow list with regex patterns for `dashboardilgd.com` and Vercel subdomains, and handle all preflight requests
- forward `OPTIONS` requests in Vercel routing so preflights reach Express and emit CORS headers

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm run build`
- `curl -i -X OPTIONS http://localhost:3002/api/users/login -H "Origin: https://dashboardilgd.com" -H "Access-Control-Request-Method: POST" -H "Access-Control-Request-Headers: Content-Type"`
- `curl -i -X POST http://localhost:3002/api/users/login -H "Origin: https://dashboardilgd.com" -H "Content-Type: application/json" -d '{"email":"test@example.com","password":"123"}'`


------
https://chatgpt.com/codex/tasks/task_e_68b03eb9e28883278ad4f818428a4f43