### PR TITLE
Fix CORS preflight by specifying allowed origins

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -9,14 +9,21 @@ import shiftRoute from "./routes/ShiftRoute";
 
 const app = express();
 
+const allowedOrigins = [
+  process.env.FRONTEND_URL,
+  "https://dashboardilgd.com",
+].filter(Boolean) as string[];
+
 app.use(
   cors({
-    origin: '*',
+    origin: allowedOrigins,
     methods: ["GET", "POST", "PUT", "DELETE", "OPTIONS"],
     allowedHeaders: ["Content-Type", "Authorization"],
     credentials: true,
   })
 );
+
+app.options("*", cors({ origin: allowedOrigins, credentials: true }));
 
 // Body parsers
 app.use(express.json());


### PR DESCRIPTION
## Summary
- configure CORS to only allow whitelisted origins
- explicitly handle preflight OPTIONS requests

## Testing
- `npm test` *(fails: sh: 1: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b05f19475883279640fe44aa7eeb2d