### PR TITLE
Handle CORS preflight for all routes

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -19,8 +19,6 @@ const allowlist = new Set([
 
 const corsOptions: cors.CorsOptions = {
     origin(origin, cb) {
-        console.log(allowlist);
-        console.log("origin", origin);
         // allow tools like curl/Postman (no origin)
         if (!origin) return cb(null, true);
         return allowlist.has(origin) ? cb(null, true) : cb(new Error("Not allowed by CORS"));
@@ -32,7 +30,9 @@ const corsOptions: cors.CorsOptions = {
 
 // 2) CORS must run before body parsers/routes; include OPTIONS
 app.use(cors(corsOptions));
-app.options("*", cors(corsOptions)); // handle preflight for all routes
+// Express 5 no longer supports the "*" wildcard; use RegExp to handle all
+// preflight requests regardless of the path.
+app.options(/.*/, cors(corsOptions));
 
 // 3) Body parsers
 app.use(express.json());


### PR DESCRIPTION
## Summary
- Use a RegExp-based `app.options` handler so Express 5 can respond to any preflight request without `path-to-regexp` errors
- Drop leftover debug logging from the CORS origin callback

## Testing
- `npm test` *(fails: sh: 1: jest: not found)*
- `npm run lint` *(fails: ESLint couldn't find an eslint.config.js file)*
- `npm run build`
- `npm start`


------
https://chatgpt.com/codex/tasks/task_e_68b554e66688832796a578525f0a3c35