### PR TITLE
Proxy API requests through Vercel rewrites

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,6 @@
       "dependencies": {
         "@vercel/node": "^5.3.15",
         "bcrypt": "^6.0.0",
-        "cors": "^2.8.5",
         "express": "^5.1.0",
         "jsonwebtoken": "^9.0.2",
         "mysql2": "^3.14.1",
@@ -17,7 +16,6 @@
       },
       "devDependencies": {
         "@types/bcrypt": "^6.0.0",
-        "@types/cors": "^2.8.19",
         "@types/express": "^5.0.3",
         "@types/jsonwebtoken": "^9.0.10",
         "@types/node": "^24.3.0",
@@ -524,16 +522,6 @@
       "version": "3.4.38",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
       "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
-    "node_modules/@types/cors": {
-      "version": "2.8.19",
-      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.19.tgz",
-      "integrity": "sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1384,19 +1372,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.6.0"
-      }
-    },
-    "node_modules/cors": {
-      "version": "2.8.5",
-      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
-      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
-      "license": "MIT",
-      "dependencies": {
-        "object-assign": "^4",
-        "vary": "^1"
-      },
-      "engines": {
-        "node": ">= 0.10"
       }
     },
     "node_modules/create-require": {
@@ -5985,15 +5960,6 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC"
-    },
-    "node_modules/object-assign": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/object-inspect": {
       "version": "1.13.4",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
   "dependencies": {
     "@vercel/node": "^5.3.15",
     "bcrypt": "^6.0.0",
-    "cors": "^2.8.5",
     "express": "^5.1.0",
     "jsonwebtoken": "^9.0.2",
     "mysql2": "^3.14.1",
@@ -19,7 +18,6 @@
   },
   "devDependencies": {
     "@types/bcrypt": "^6.0.0",
-    "@types/cors": "^2.8.19",
     "@types/express": "^5.0.3",
     "@types/jsonwebtoken": "^9.0.10",
     "@types/node": "^24.3.0",

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,7 +1,6 @@
 import "reflect-metadata";
 import "./container";
 import express from "express";
-import cors from "cors";
 import userRoute from "./routes/UserRoute";
 import chatterRoute from "./routes/ChatterRoute";
 import employeeEarningRoute from "./routes/EmployeeEarningRoute";
@@ -9,42 +8,19 @@ import shiftRoute from "./routes/ShiftRoute";
 
 const app = express();
 
-// 1) Explicit allowlist (no "*")
-const allowlist = new Set([
-    "http://localhost:3000",
-    "https://dashboardilgd.com",
-    "https://www.dashboardilgd.com",
-    // add preview URLs if needed, e.g. "https://dashboardilgd-git-main-<user>.vercel.app"
-]);
+// CORS is handled by Vercel's reverse proxy, so no middleware is required here.
 
-const corsOptions: cors.CorsOptions = {
-    origin(origin, cb) {
-        // allow tools like curl/Postman (no origin)
-        if (!origin) return cb(null, true);
-        return allowlist.has(origin) ? cb(null, true) : cb(new Error("Not allowed by CORS"));
-    },
-    methods: ["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
-    allowedHeaders: ["Content-Type", "Authorization"],
-    optionsSuccessStatus: 200,
-};
-
-// 2) CORS must run before body parsers/routes; include OPTIONS
-app.use(cors(corsOptions));
-// Express 5 no longer supports the "*" wildcard; use RegExp to handle all
-// preflight requests regardless of the path.
-app.options(/.*/, cors(corsOptions));
-
-// 3) Body parsers
+// Body parsers
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
 
-// 4) Routes
+// Routes
 app.use("/api/users", userRoute);
 app.use("/api/chatters", chatterRoute);
 app.use("/api/employee-earnings", employeeEarningRoute);
 app.use("/api/shifts", shiftRoute);
 
-// 5) Health
+// Health
 app.get("/api/health", (_req, res) => res.json({ ok: true }));
 
 export default app;

--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,10 @@
 
 {
-  "version": 2
+  "version": 2,
+  "rewrites": [
+    {
+      "source": "/api/:path*",
+      "destination": "https://your-backend-url.com/api/:path*"
+    }
+  ]
 }


### PR DESCRIPTION
## Summary
- remove Express CORS middleware and rely on Vercel's reverse proxy
- add example rewrite in `vercel.json` to forward `/api/*` requests
- drop unused `cors` dependencies

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_68b56420682883279b4c45a565a6e059