### PR TITLE
Fix shift time retrieval by using UTC timezone

### DIFF
--- a/src/config/database.ts
+++ b/src/config/database.ts
@@ -14,6 +14,8 @@ const pool = mysql.createPool({
     queueLimit: 0,
     supportBigNumbers: true,
     bigNumberStrings:  true,
+    // ensure MySQL times are treated as UTC to avoid implicit timezone shifts
+    timezone: 'Z',
     dateStrings: ["DATE"],
 });
 


### PR DESCRIPTION
## Summary
- Configure MySQL pool to use UTC timezone to avoid 2-hour offset when fetching shift start and end times

## Testing
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b6b74288288327831f142f1ec60e6a