### PR TITLE
Add F2F unlock earnings sync

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
     "start": "node build/server.js",
     "dev": "ts-node-dev --files --transpile-only --respawn --inspect=4321 --project tsconfig.json src/server.ts",
     "lint": "eslint 'src/**/*.ts'",
-    "test": "jest"
+    "test": "jest",
+    "sync:earnings": "ts-node src/tasks/syncUnlockEarnings.ts"
   },
   "dependencies": {
     "@vercel/node": "^5.3.15",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
     "dev": "ts-node-dev --files --transpile-only --respawn --inspect=4321 --project tsconfig.json src/server.ts",
     "lint": "eslint 'src/**/*.ts'",
     "test": "jest",
-    "sync:earnings": "ts-node src/tasks/syncUnlockEarnings.ts"
+    "sync:earnings": "ts-node src/tasks/syncUnlockEarnings.ts",
+    "sync:transactions": "ts-node src/tasks/syncTransactionEarnings.ts"
   },
   "dependencies": {
     "@vercel/node": "^5.3.15",

--- a/src/business/models/EmployeeEarningModel.ts
+++ b/src/business/models/EmployeeEarningModel.ts
@@ -1,6 +1,6 @@
 export class EmployeeEarningModel {
     constructor(
-        private _id: number,
+        private _id: string,
         private _chatterId: number,
         private _date: Date,           // business date
         private _amount: number,       // decimal(10,2)
@@ -20,7 +20,7 @@ export class EmployeeEarningModel {
     }
 
     // Getters
-    get id(): number { return this._id; }
+    get id(): string { return this._id; }
     get chatterId(): number { return this._chatterId; }
     get date(): Date { return this._date; }
     get amount(): number { return this._amount; }
@@ -29,7 +29,7 @@ export class EmployeeEarningModel {
 
     static fromRow(r: any): EmployeeEarningModel {
         return new EmployeeEarningModel(
-            Number(r.id),
+            String(r.id),
             Number(r.chatter_id),
             new Date(r.date),
             Number(r.amount),

--- a/src/business/models/ModelModel.ts
+++ b/src/business/models/ModelModel.ts
@@ -1,0 +1,35 @@
+export class ModelModel {
+    constructor(
+        private _id: number,
+        private _displayName: string,
+        private _username: string,
+        private _commissionRate: number,
+        private _createdAt: Date,
+    ) {}
+
+    public toJSON(): Record<string, any> {
+        return {
+            id: this.id,
+            displayName: this.displayName,
+            username: this.username,
+            commissionRate: this.commissionRate,
+            createdAt: this.createdAt,
+        };
+    }
+
+    get id(): number { return this._id; }
+    get displayName(): string { return this._displayName; }
+    get username(): string { return this._username; }
+    get commissionRate(): number { return this._commissionRate; }
+    get createdAt(): Date { return this._createdAt; }
+
+    static fromRow(r: any): ModelModel {
+        return new ModelModel(
+            Number(r.id),
+            String(r.display_name),
+            String(r.username),
+            Number(r.commission_rate),
+            new Date(r.created_at),
+        );
+    }
+}

--- a/src/business/models/ShiftModel.ts
+++ b/src/business/models/ShiftModel.ts
@@ -4,6 +4,7 @@ export class ShiftModel {
     constructor(
         private _id: number,
         private _chatterId: number,
+        private _modelId: number,
         private _date: Date,         // business date
         private _startTime: Date,    // datetime
         private _endTime: Date | null,      // datetime
@@ -15,6 +16,7 @@ export class ShiftModel {
         return {
             id: this.id,
             chatterId: this.chatterId,
+            modelId: this.modelId,
             date: this.date,
             startTime: this.startTime,
             endTime: this.endTime,
@@ -26,6 +28,7 @@ export class ShiftModel {
     // Getters
     get id(): number { return this._id; }
     get chatterId(): number { return this._chatterId; }
+    get modelId(): number { return this._modelId; }
     get date(): Date { return this._date; }
     get startTime(): Date { return this._startTime; }
     get endTime(): Date | null { return this._endTime; }
@@ -36,6 +39,7 @@ export class ShiftModel {
         return new ShiftModel(
             Number(r.id),
             Number(r.chatter_id),
+            Number(r.model_id),
             new Date(r.date),
             new Date(r.start_time),
             r.end_time ? new Date(r.end_time) : null,

--- a/src/business/models/ShiftModel.ts
+++ b/src/business/models/ShiftModel.ts
@@ -4,7 +4,7 @@ export class ShiftModel {
     constructor(
         private _id: number,
         private _chatterId: number,
-        private _modelId: number,
+        private _modelIds: number[],
         private _date: Date,         // business date
         private _startTime: Date,    // datetime
         private _endTime: Date | null,      // datetime
@@ -16,7 +16,7 @@ export class ShiftModel {
         return {
             id: this.id,
             chatterId: this.chatterId,
-            modelId: this.modelId,
+            modelIds: this.modelIds,
             date: this.date,
             startTime: this.startTime,
             endTime: this.endTime,
@@ -28,7 +28,7 @@ export class ShiftModel {
     // Getters
     get id(): number { return this._id; }
     get chatterId(): number { return this._chatterId; }
-    get modelId(): number { return this._modelId; }
+    get modelIds(): number[] { return this._modelIds; }
     get date(): Date { return this._date; }
     get startTime(): Date { return this._startTime; }
     get endTime(): Date | null { return this._endTime; }
@@ -36,10 +36,13 @@ export class ShiftModel {
     get createdAt(): Date { return this._createdAt; }
 
     static fromRow(r: any): ShiftModel {
+        const ids = typeof r.model_ids === 'string'
+            ? r.model_ids.split(',').map((v: string) => Number(v)).filter((n: number) => !Number.isNaN(n))
+            : [];
         return new ShiftModel(
             Number(r.id),
             Number(r.chatter_id),
-            Number(r.model_id),
+            ids,
             new Date(r.date),
             new Date(r.start_time),
             r.end_time ? new Date(r.end_time) : null,

--- a/src/business/services/EmployeeEarningService.ts
+++ b/src/business/services/EmployeeEarningService.ts
@@ -1,18 +1,22 @@
 import {inject, injectable} from "tsyringe";
 import {IEmployeeEarningRepository} from "../../data/interfaces/IEmployeeEarningRepository";
 import {EmployeeEarningModel} from "../models/EmployeeEarningModel";
+import {F2FTransactionSyncService} from "./F2FTransactionSyncService";
 
 @injectable()
 export class EmployeeEarningService {
     constructor(
-        @inject("IEmployeeEarningRepository") private earningRepo: IEmployeeEarningRepository
+        @inject("IEmployeeEarningRepository") private earningRepo: IEmployeeEarningRepository,
+        private txnSync: F2FTransactionSyncService
     ) {}
 
     public async getAll(): Promise<EmployeeEarningModel[]> {
+        await this.txnSync.syncRecentPayPerMessage().catch(console.error);
         return this.earningRepo.findAll();
     }
 
     public async getById(id: number): Promise<EmployeeEarningModel | null> {
+        await this.txnSync.syncRecentPayPerMessage().catch(console.error);
         return this.earningRepo.findById(id);
     }
 

--- a/src/business/services/EmployeeEarningService.ts
+++ b/src/business/services/EmployeeEarningService.ts
@@ -15,7 +15,7 @@ export class EmployeeEarningService {
         return this.earningRepo.findAll();
     }
 
-    public async getById(id: number): Promise<EmployeeEarningModel | null> {
+    public async getById(id: string): Promise<EmployeeEarningModel | null> {
         await this.txnSync.syncRecentPayPerMessage().catch(console.error);
         return this.earningRepo.findById(id);
     }
@@ -24,11 +24,11 @@ export class EmployeeEarningService {
         return this.earningRepo.create(data);
     }
 
-    public async update(id: number, data: { chatterId?: number; date?: Date; amount?: number; description?: string | null; }): Promise<EmployeeEarningModel | null> {
+    public async update(id: string, data: { chatterId?: number; date?: Date; amount?: number; description?: string | null; }): Promise<EmployeeEarningModel | null> {
         return this.earningRepo.update(id, data);
     }
 
-    public async delete(id: number): Promise<void> {
+    public async delete(id: string): Promise<void> {
         await this.earningRepo.delete(id);
     }
 }

--- a/src/business/services/EmployeeEarningService.ts
+++ b/src/business/services/EmployeeEarningService.ts
@@ -11,6 +11,7 @@ export class EmployeeEarningService {
     ) {}
 
     public async getAll(): Promise<EmployeeEarningModel[]> {
+        console.log("Syncing recent pay per message transactions...");
         await this.txnSync.syncRecentPayPerMessage().catch(console.error);
         return this.earningRepo.findAll();
     }

--- a/src/business/services/F2FTransactionSyncService.ts
+++ b/src/business/services/F2FTransactionSyncService.ts
@@ -86,7 +86,11 @@ export class F2FTransactionSyncService {
             const shift = await this.shiftRepo.findShiftForModelAt(modelId, ts);
             console.log(`  -> model ${creator} id ${modelId}, found shift: ${shift ? shift.id : 'NO SHIFT'}`);
             if (!shift) continue;
+            const id = txn.uuid;
+            const existing = await this.earningRepo.findById(id);
+            if (existing) continue;
             await this.earningRepo.create({
+                id,
                 chatterId: shift.chatterId,
                 date: shift.date,
                 amount: revenue,

--- a/src/business/services/F2FTransactionSyncService.ts
+++ b/src/business/services/F2FTransactionSyncService.ts
@@ -91,7 +91,7 @@ export class F2FTransactionSyncService {
             if (!modelId) continue;
             const ts = new Date(detail.created);
             const shift = await this.shiftRepo.findShiftForModelAt(modelId, ts);
-            console.log(`  -> model ${creator} id ${modelId}, found shift: ${shift ? shift.id : 'NO SHIFT'}`);
+            console.log(`  -> model ${creator} id ${modelId}, found shift: ${shift ? shift.id + ' models:' + shift.modelIds.join(',') : 'NO SHIFT'}`);
             if (!shift) continue;
             const id = txn.uuid;
             const existing = await this.earningRepo.findById(id);

--- a/src/business/services/F2FTransactionSyncService.ts
+++ b/src/business/services/F2FTransactionSyncService.ts
@@ -1,0 +1,100 @@
+import {inject, injectable} from "tsyringe";
+import {IShiftRepository} from "../../data/interfaces/IShiftRepository";
+import {IEmployeeEarningRepository} from "../../data/interfaces/IEmployeeEarningRepository";
+import {IModelRepository} from "../../data/interfaces/IModelRepository";
+
+const BASE = process.env.F2F_BASE || "https://f2f.com";
+const UA = process.env.UA ||
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36";
+const COOKIES = "shield_FPC=SCCw3sIA5nuudpQTWSQODJuLw7qlxzBoKg; splash=true; intercom-device-id-r1f7b1gp=aeeb0d35-2f49-492d-848a" +
+    "-e1b7a48c63e3; csrftoken=88vIqGRLyEADnlumGSNq9f32CzsJSy8b; sessionid=bq3qq9gbvbrmh2hjb79grpli6s7fldg4; intercom-session-r1f7b1gp" +
+    "=WEVrT1Z4aHFaOG5lV2tZRExDT3MyTmltcFFwN3Q5MTR1TTdZWE1Fc0RTaDFZMmdkbDNucEtrSlI2Y3YvNGFDQnUyTHN0dGNScmJ4aVAxcVBtS3Zwa1FGbExMNitVNzk" +
+    "zRjc5QzRUYlFlOUE9LS1NYk1YOHNIK1ZTSVFURlFscWZFSHNnPT0=--87dd43f168c18288574dc4725278bf900e6e0307";
+
+const sleep = (ms: number) => new Promise(res => setTimeout(res, ms));
+
+@injectable()
+export class F2FTransactionSyncService {
+    private lastSeenUuid: string | null = null;
+
+    constructor(
+        @inject("IShiftRepository") private shiftRepo: IShiftRepository,
+        @inject("IEmployeeEarningRepository") private earningRepo: IEmployeeEarningRepository,
+        @inject("IModelRepository") private modelRepo: IModelRepository,
+    ) {}
+
+    private headers(): Record<string, string> {
+        return {
+            accept: "application/json, text/plain, */*",
+            "accept-language": "nl-NL,nl;q=0.9,en-US;q=0.8,en;q=0.7",
+            "user-agent": UA,
+            cookie: COOKIES,
+            origin: BASE,
+            referer: `${BASE}/agency/transactions/`,
+        };
+    }
+
+    private async fetchTransactions(): Promise<any[]> {
+        const res = await fetch(`${BASE}/api/agency/transactions/`, {headers: this.headers()});
+        const ct = res.headers.get("content-type") || "";
+        const text = await res.text();
+        if (!res.ok || ct.includes("text/html")) {
+            throw new Error(`transactions list error ${res.status}. First 300 chars:\n${text.slice(0,300)}`);
+        }
+        const data = JSON.parse(text);
+        return data.results || [];
+    }
+
+    private async fetchTransactionDetail(id: string): Promise<any> {
+        const res = await fetch(`${BASE}/api/agency/transactions/${id}/`, {headers: this.headers()});
+        const ct = res.headers.get("content-type") || "";
+        const text = await res.text();
+        if (!res.ok || ct.includes("text/html")) {
+            throw new Error(`transaction ${id} error ${res.status}. First 300 chars:\n${text.slice(0,300)}`);
+        }
+        return JSON.parse(text);
+    }
+
+    public async syncRecentPayPerMessage(): Promise<void> {
+        if (!COOKIES) {
+            throw new Error("F2F_COOKIES env var required");
+        }
+
+        const list = await this.fetchTransactions();
+        const payPerMessages = list.filter((t: any) => t.object_type === "paypermessage");
+        if (!payPerMessages.length) return;
+
+        let newTxns = payPerMessages;
+        if (this.lastSeenUuid) {
+            const idx = payPerMessages.findIndex((t: any) => t.uuid === this.lastSeenUuid);
+            if (idx >= 0) newTxns = payPerMessages.slice(0, idx);
+        }
+        if (!newTxns.length) return;
+
+        const models = await this.modelRepo.findAll();
+        const modelMap = new Map<string, number>();
+        for (const m of models) modelMap.set(m.username, m.id);
+
+        // process oldest first
+        for (const txn of newTxns.reverse()) {
+            const detail = await this.fetchTransactionDetail(txn.uuid);
+            const revenue = Number(detail.net_revenue || detail.revenue || 0);
+            const creator = detail.creator || txn.creator;
+            const modelId = modelMap.get(creator);
+            if (!modelId) continue;
+            const ts = new Date(detail.created);
+            const shift = await this.shiftRepo.findShiftForModelAt(modelId, ts);
+            if (!shift) continue;
+            await this.earningRepo.create({
+                chatterId: shift.chatterId,
+                date: shift.date,
+                amount: revenue,
+                description: `paypermessage: ${detail.user}`,
+            });
+            await sleep(50);
+        }
+
+        this.lastSeenUuid = payPerMessages[0].uuid;
+    }
+}
+

--- a/src/business/services/F2FUnlockSyncService.ts
+++ b/src/business/services/F2FUnlockSyncService.ts
@@ -1,0 +1,133 @@
+import {inject, injectable} from "tsyringe";
+import {IChatterRepository} from "../../data/interfaces/IChatterRepository";
+import {IShiftRepository} from "../../data/interfaces/IShiftRepository";
+import {IEmployeeEarningRepository} from "../../data/interfaces/IEmployeeEarningRepository";
+
+const BASE = process.env.F2F_BASE || "https://f2f.com";
+const UA = process.env.UA ||
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36";
+const COOKIES = process.env.F2F_COOKIES || "";
+
+const sleep = (ms: number) => new Promise(res => setTimeout(res, ms));
+
+@injectable()
+export class F2FUnlockSyncService {
+    constructor(
+        @inject("IChatterRepository") private chatterRepo: IChatterRepository,
+        @inject("IShiftRepository") private shiftRepo: IShiftRepository,
+        @inject("IEmployeeEarningRepository") private earningRepo: IEmployeeEarningRepository,
+    ) {}
+
+    private headersFor(creatorSlug?: string): Record<string, string> {
+        const h: Record<string, string> = {
+            accept: "application/json, text/plain, */*",
+            "accept-language": "nl-NL,nl;q=0.9,en-US;q=0.8,en;q=0.7",
+            "user-agent": UA,
+            cookie: COOKIES,
+            origin: BASE,
+            referer: `${BASE}/`,
+        };
+        if (creatorSlug) h["impersonate-user"] = creatorSlug;
+        return h;
+    }
+
+    private async fetchAllPages(startUrl: string, headers: Record<string, string>, label = ""): Promise<any[]> {
+        let url: string | null = startUrl;
+        const all: any[] = [];
+        const seen = new Set<string>();
+
+        while (url) {
+            if (seen.has(url)) break;
+            seen.add(url);
+
+            const res = await fetch(url, {headers});
+            const ct = res.headers.get("content-type") || "";
+            const text = await res.text();
+            if (!res.ok || ct.includes("text/html")) {
+                throw new Error(`[${label}] Blocked/error ${res.status}. First 300 chars:\n${text.slice(0, 300)}`);
+            }
+            const page = JSON.parse(text);
+            const items = Array.isArray(page) ? page : page.results || [];
+            all.push(...items);
+            url = page.next || null;
+            if (url) await sleep(120);
+        }
+        return all;
+    }
+
+    private async getAllCreators(): Promise<string[]> {
+        const creators = await this.fetchAllPages(`${BASE}/api/agency/creators/`, this.headersFor(), "creators");
+        const slugs = creators
+            .map((c: any) => c.username || c.slug || c.id || c.name)
+            .filter(Boolean);
+        return Array.from(new Set(slugs));
+    }
+
+    private async getAllChatsForCreator(creator: string, fromDate: Date, toDate: Date): Promise<any[]> {
+        const chats = await this.fetchAllPages(
+            `${BASE}/api/chats/?ordering=newest-first`,
+            this.headersFor(creator),
+            `chats:${creator}`
+        );
+        const inWindow = (iso: string) => {
+            if (!iso) return false;
+            const d = new Date(iso);
+            return !Number.isNaN(d.getTime()) && d >= fromDate && d <= toDate;
+        };
+        return chats
+            .filter((c: any) => inWindow(c.message?.datetime))
+            .map((c: any) => ({
+                id: c.uuid || c.id,
+                title: c.title || "",
+                username: c.other_user?.username || null,
+                lastMessageAt: c.message?.datetime || null,
+            }))
+            .filter((c: any) => !!c.id);
+    }
+
+    private async getAllMessagesForChat(creator: string, chatId: string): Promise<any[]> {
+        return this.fetchAllPages(`${BASE}/api/chats/${chatId}/messages/`, this.headersFor(creator), `msgs:${creator}:${chatId}`);
+    }
+
+    private pickUnlocksInWindow(messages: any[], fromDate: Date, toDate: Date): {datetime: string, price: number}[] {
+        return messages
+            .filter(m =>
+                m.unlock &&
+                typeof m.unlock.price !== "undefined" &&
+                m.datetime &&
+                new Date(m.datetime) >= fromDate &&
+                new Date(m.datetime) <= toDate
+            )
+            .map(m => ({ datetime: m.datetime, price: Number(m.unlock.price) || 0 }));
+    }
+
+    public async syncLast24Hours(): Promise<void> {
+        if (!COOKIES) {
+            throw new Error("F2F_COOKIES env var required");
+        }
+        const now = new Date();
+        const from = new Date(now.getTime() - 24 * 60 * 60 * 1000);
+        const creators = await this.getAllCreators();
+        for (const creator of creators) {
+            const chatter = await this.chatterRepo.findByEmail(creator);
+            if (!chatter) continue;
+            const chats = await this.getAllChatsForCreator(creator, from, now);
+            for (const chat of chats) {
+                const msgs = await this.getAllMessagesForChat(creator, chat.id);
+                const unlocks = this.pickUnlocksInWindow(msgs, from, now);
+                for (const u of unlocks) {
+                    const ts = new Date(u.datetime);
+                    const shift = await this.shiftRepo.findShiftForChatterAt(chatter.id, ts);
+                    if (!shift) continue;
+                    await this.earningRepo.create({
+                        chatterId: chatter.id,
+                        date: shift.date,
+                        amount: u.price,
+                        description: `unlock:${chat.id}:${u.datetime}`,
+                    });
+                }
+                await sleep(100);
+            }
+        }
+    }
+}

--- a/src/business/services/F2FUnlockSyncService.ts
+++ b/src/business/services/F2FUnlockSyncService.ts
@@ -123,7 +123,7 @@ export class F2FUnlockSyncService {
                         chatterId: chatter?.id || 0,
                         date: shift?.date || ts,
                         amount: u.price,
-                        description: `unlock:${chat.id}:${u.datetime}`,
+                        description: `unlock: ${creator} @ ${u.datetime.split("T")[0]}`,
                     });
                 }
                 await sleep(100);

--- a/src/business/services/F2FUnlockSyncService.ts
+++ b/src/business/services/F2FUnlockSyncService.ts
@@ -66,7 +66,7 @@ export class F2FUnlockSyncService {
     private async getAllChatsForCreator(creator: string, fromDate: Date, toDate: Date): Promise<any[]> {
         console.log(`F2F: Fetching chats for ${creator}`);
         const chats = await this.fetchAllPages(
-            `${BASE}/api/chats/?ordering=newest-first`,
+            `${BASE}/api/chats/?ordering=newest-first?read=false`,
             this.headersFor(creator),
             `chats:${creator}`
         );
@@ -93,9 +93,11 @@ export class F2FUnlockSyncService {
             const d = new Date(last.datetime);
             return Number.isNaN(d.getTime()) || d < fromDate;
         };
+        const headers = this.headersFor(creator);
+        headers["X-Mark-Read"] = "false";
         return this.fetchAllPages(
-            `${BASE}/api/chats/${chatId}/messages/`,
-            this.headersFor(creator),
+            `${BASE}/api/chats/${chatId}/messages/?read=false`,
+            headers,
             `msgs:${creator}:${chatId}`,
             stopWhen
         );
@@ -107,8 +109,8 @@ export class F2FUnlockSyncService {
                 m.unlock &&
                 typeof m.unlock.price !== "undefined" &&
                 m.unlocked &&
-                new Date(m.unlocked) >= fromDate &&
-                new Date(m.unlocked) <= toDate
+                new Date(m.datetime) >= fromDate &&
+                new Date(m.datetime) <= toDate
             )
             .map(m => ({ datetime: m.unlocked, price: Number(m.unlock.price) || 0 }));
     }

--- a/src/business/services/ModelService.ts
+++ b/src/business/services/ModelService.ts
@@ -1,0 +1,30 @@
+import {inject, injectable} from "tsyringe";
+import {IModelRepository} from "../../data/interfaces/IModelRepository";
+import {ModelModel} from "../models/ModelModel";
+
+@injectable()
+export class ModelService {
+    constructor(
+        @inject("IModelRepository") private modelRepo: IModelRepository
+    ) {}
+
+    public async getAll(): Promise<ModelModel[]> {
+        return this.modelRepo.findAll();
+    }
+
+    public async getById(id: number): Promise<ModelModel | null> {
+        return this.modelRepo.findById(id);
+    }
+
+    public async create(data: { displayName: string; username: string; commissionRate: number; }): Promise<ModelModel> {
+        return this.modelRepo.create(data);
+    }
+
+    public async update(id: number, data: { displayName?: string; username?: string; commissionRate?: number; }): Promise<ModelModel | null> {
+        return this.modelRepo.update(id, data);
+    }
+
+    public async delete(id: number): Promise<void> {
+        await this.modelRepo.delete(id);
+    }
+}

--- a/src/business/services/ShiftService.ts
+++ b/src/business/services/ShiftService.ts
@@ -17,19 +17,19 @@ export class ShiftService {
         return this.shiftRepo.findById(id);
     }
 
-    public async create(data: { chatterId: number; modelId: number; date: Date; start_time: Date; end_time?: Date | null; status: ShiftStatus; }): Promise<ShiftModel> {
+    public async create(data: { chatterId: number; modelIds: number[]; date: Date; start_time: Date; end_time?: Date | null; status: ShiftStatus; }): Promise<ShiftModel> {
         return this.shiftRepo.create(data);
     }
 
-    public async update(id: number, data: { chatterId?: number; modelId?: number; date?: Date; start_time?: Date; end_time?: Date | null; status?: ShiftStatus; }): Promise<ShiftModel | null> {
+    public async update(id: number, data: { chatterId?: number; modelIds?: number[]; date?: Date; start_time?: Date; end_time?: Date | null; status?: ShiftStatus; }): Promise<ShiftModel | null> {
         return this.shiftRepo.update(id, data);
     }
 
-    public async clockIn(chatterId: number, modelId: number): Promise<ShiftModel> {
+    public async clockIn(chatterId: number, modelIds: number[]): Promise<ShiftModel> {
         const now = new Date();
         return this.shiftRepo.create({
             chatterId,
-            modelId,
+            modelIds,
             date: now,
             start_time: now,
             end_time: null,

--- a/src/business/services/ShiftService.ts
+++ b/src/business/services/ShiftService.ts
@@ -17,18 +17,19 @@ export class ShiftService {
         return this.shiftRepo.findById(id);
     }
 
-    public async create(data: { chatterId: number; date: Date; start_time: Date; end_time?: Date | null; status: ShiftStatus; }): Promise<ShiftModel> {
+    public async create(data: { chatterId: number; modelId: number; date: Date; start_time: Date; end_time?: Date | null; status: ShiftStatus; }): Promise<ShiftModel> {
         return this.shiftRepo.create(data);
     }
 
-    public async update(id: number, data: { chatterId?: number; date?: Date; start_time?: Date; end_time?: Date | null; status?: ShiftStatus; }): Promise<ShiftModel | null> {
+    public async update(id: number, data: { chatterId?: number; modelId?: number; date?: Date; start_time?: Date; end_time?: Date | null; status?: ShiftStatus; }): Promise<ShiftModel | null> {
         return this.shiftRepo.update(id, data);
     }
 
-    public async clockIn(chatterId: number): Promise<ShiftModel> {
+    public async clockIn(chatterId: number, modelId: number): Promise<ShiftModel> {
         const now = new Date();
         return this.shiftRepo.create({
             chatterId,
+            modelId,
             date: now,
             start_time: now,
             end_time: null,

--- a/src/container/index.ts
+++ b/src/container/index.ts
@@ -15,6 +15,7 @@ import {CommissionService} from "../business/services/CommissionService";
 import {ICommissionRepository} from "../data/interfaces/ICommissionRepository";
 import {CommissionRepository} from "../data/repositories/CommissionRepository";
 import {F2FUnlockSyncService} from "../business/services/F2FUnlockSyncService";
+import {F2FTransactionSyncService} from "../business/services/F2FTransactionSyncService";
 import {ModelService} from "../business/services/ModelService";
 import {IModelRepository} from "../data/interfaces/IModelRepository";
 import {ModelRepository} from "../data/repositories/ModelRepository";
@@ -49,3 +50,4 @@ container.register<IModelRepository>("IModelRepository", {
     useClass: ModelRepository,
 });
 container.register("F2FUnlockSyncService", { useClass: F2FUnlockSyncService });
+container.registerSingleton(F2FTransactionSyncService);

--- a/src/container/index.ts
+++ b/src/container/index.ts
@@ -15,6 +15,9 @@ import {CommissionService} from "../business/services/CommissionService";
 import {ICommissionRepository} from "../data/interfaces/ICommissionRepository";
 import {CommissionRepository} from "../data/repositories/CommissionRepository";
 import {F2FUnlockSyncService} from "../business/services/F2FUnlockSyncService";
+import {ModelService} from "../business/services/ModelService";
+import {IModelRepository} from "../data/interfaces/IModelRepository";
+import {ModelRepository} from "../data/repositories/ModelRepository";
 
 container.register("UserService", { useClass: UserService });
 
@@ -40,5 +43,9 @@ container.register<IShiftRepository>("IShiftRepository", {
 container.register("CommissionService", { useClass: CommissionService });
 container.register<ICommissionRepository>("ICommissionRepository", {
     useClass: CommissionRepository,
+});
+container.register("ModelService", { useClass: ModelService });
+container.register<IModelRepository>("IModelRepository", {
+    useClass: ModelRepository,
 });
 container.register("F2FUnlockSyncService", { useClass: F2FUnlockSyncService });

--- a/src/container/index.ts
+++ b/src/container/index.ts
@@ -14,6 +14,7 @@ import {ShiftRepository} from "../data/repositories/ShiftRepository";
 import {CommissionService} from "../business/services/CommissionService";
 import {ICommissionRepository} from "../data/interfaces/ICommissionRepository";
 import {CommissionRepository} from "../data/repositories/CommissionRepository";
+import {F2FUnlockSyncService} from "../business/services/F2FUnlockSyncService";
 
 container.register("UserService", { useClass: UserService });
 
@@ -40,3 +41,4 @@ container.register("CommissionService", { useClass: CommissionService });
 container.register<ICommissionRepository>("ICommissionRepository", {
     useClass: CommissionRepository,
 });
+container.register("F2FUnlockSyncService", { useClass: F2FUnlockSyncService });

--- a/src/controllers/EmployeeEarningController.ts
+++ b/src/controllers/EmployeeEarningController.ts
@@ -19,7 +19,7 @@ export class EmployeeEarningController {
 
     public async getById(req: Request, res: Response): Promise<void> {
         try {
-            const id = Number(req.params.id);
+            const id = req.params.id;
             const earning = await this.service.getById(id);
             if (!earning) {
                 res.status(404).send("Earning not found");
@@ -44,7 +44,7 @@ export class EmployeeEarningController {
 
     public async update(req: Request, res: Response): Promise<void> {
         try {
-            const id = Number(req.params.id);
+            const id = req.params.id;
             const earning = await this.service.update(id, req.body);
             if (!earning) {
                 res.status(404).send("Earning not found");
@@ -59,7 +59,7 @@ export class EmployeeEarningController {
 
     public async delete(req: Request, res: Response): Promise<void> {
         try {
-            const id = Number(req.params.id);
+            const id = req.params.id;
             await this.service.delete(id);
             res.sendStatus(204);
         } catch (err) {

--- a/src/controllers/ModelController.ts
+++ b/src/controllers/ModelController.ts
@@ -1,0 +1,70 @@
+import {Request, Response} from "express";
+import {container} from "tsyringe";
+import {ModelService} from "../business/services/ModelService";
+
+export class ModelController {
+    private get service(): ModelService {
+        return container.resolve(ModelService);
+    }
+
+    public async getAll(_req: Request, res: Response): Promise<void> {
+        try {
+            const models = await this.service.getAll();
+            res.json(models.map(m => m.toJSON()));
+        } catch (err) {
+            console.error(err);
+            res.status(500).send("Error fetching models");
+        }
+    }
+
+    public async getById(req: Request, res: Response): Promise<void> {
+        try {
+            const id = Number(req.params.id);
+            const model = await this.service.getById(id);
+            if (!model) {
+                res.status(404).send("Model not found");
+                return;
+            }
+            res.json(model.toJSON());
+        } catch (err) {
+            console.error(err);
+            res.status(500).send("Error fetching model");
+        }
+    }
+
+    public async create(req: Request, res: Response): Promise<void> {
+        try {
+            const model = await this.service.create(req.body);
+            res.status(201).json(model.toJSON());
+        } catch (err) {
+            console.error(err);
+            res.status(500).send("Error creating model");
+        }
+    }
+
+    public async update(req: Request, res: Response): Promise<void> {
+        try {
+            const id = Number(req.params.id);
+            const model = await this.service.update(id, req.body);
+            if (!model) {
+                res.status(404).send("Model not found");
+                return;
+            }
+            res.json(model.toJSON());
+        } catch (err) {
+            console.error(err);
+            res.status(500).send("Error updating model");
+        }
+    }
+
+    public async delete(req: Request, res: Response): Promise<void> {
+        try {
+            const id = Number(req.params.id);
+            await this.service.delete(id);
+            res.sendStatus(204);
+        } catch (err) {
+            console.error(err);
+            res.status(500).send("Error deleting model");
+        }
+    }
+}

--- a/src/controllers/ShiftController.ts
+++ b/src/controllers/ShiftController.ts
@@ -35,7 +35,11 @@ export class ShiftController {
 
     public async create(req: Request, res: Response): Promise<void> {
         try {
-            const shift = await this.service.create(req.body);
+            const data = {
+                ...req.body,
+                modelIds: Array.isArray(req.body.modelIds) ? req.body.modelIds.map((n: any) => Number(n)) : [],
+            };
+            const shift = await this.service.create(data);
             res.status(201).json(shift.toJSON());
         } catch (err) {
             console.error(err);
@@ -45,8 +49,11 @@ export class ShiftController {
 
     public async clockIn(req: Request, res: Response): Promise<void> {
         try {
-            const {chatterId, modelId} = req.body;
-            const shift = await this.service.clockIn(Number(chatterId), Number(modelId));
+            const {chatterId, modelIds} = req.body;
+            const shift = await this.service.clockIn(
+                Number(chatterId),
+                Array.isArray(modelIds) ? modelIds.map((n: any) => Number(n)) : []
+            );
             res.status(201).json(shift.toJSON());
         } catch (err) {
             console.error(err);
@@ -72,7 +79,13 @@ export class ShiftController {
     public async update(req: Request, res: Response): Promise<void> {
         try {
             const id = Number(req.params.id);
-            const shift = await this.service.update(id, req.body);
+            const data = {
+                ...req.body,
+                ...(Array.isArray(req.body.modelIds)
+                    ? {modelIds: req.body.modelIds.map((n: any) => Number(n))}
+                    : {}),
+            };
+            const shift = await this.service.update(id, data);
             if (!shift) {
                 res.status(404).send("Shift not found");
                 return;

--- a/src/controllers/ShiftController.ts
+++ b/src/controllers/ShiftController.ts
@@ -45,8 +45,8 @@ export class ShiftController {
 
     public async clockIn(req: Request, res: Response): Promise<void> {
         try {
-            const {chatterId} = req.body;
-            const shift = await this.service.clockIn(Number(chatterId));
+            const {chatterId, modelId} = req.body;
+            const shift = await this.service.clockIn(Number(chatterId), Number(modelId));
             res.status(201).json(shift.toJSON());
         } catch (err) {
             console.error(err);

--- a/src/data/interfaces/IChatterRepository.ts
+++ b/src/data/interfaces/IChatterRepository.ts
@@ -4,6 +4,7 @@ import {ChatterStatus, CurrencySymbol} from "../../rename/types";
 export interface IChatterRepository {
     findAll(): Promise<ChatterModel[]>;
     findById(id: number): Promise<ChatterModel | null>;
+    findByEmail(email: string): Promise<ChatterModel | null>;
     create(data: {
         userId: number;
         email: string;

--- a/src/data/interfaces/IEmployeeEarningRepository.ts
+++ b/src/data/interfaces/IEmployeeEarningRepository.ts
@@ -17,4 +17,5 @@ export interface IEmployeeEarningRepository {
         description?: string | null;
     }): Promise<EmployeeEarningModel | null>;
     delete(id: string): Promise<void>;
+    getLastId(): Promise<string | null>;
 }

--- a/src/data/interfaces/IEmployeeEarningRepository.ts
+++ b/src/data/interfaces/IEmployeeEarningRepository.ts
@@ -2,18 +2,19 @@ import {EmployeeEarningModel} from "../../business/models/EmployeeEarningModel";
 
 export interface IEmployeeEarningRepository {
     findAll(): Promise<EmployeeEarningModel[]>;
-    findById(id: number): Promise<EmployeeEarningModel | null>;
+    findById(id: string): Promise<EmployeeEarningModel | null>;
     create(data: {
+        id?: string;
         chatterId: number;
         date: Date;
         amount: number;
         description?: string | null;
     }): Promise<EmployeeEarningModel>;
-    update(id: number, data: {
+    update(id: string, data: {
         chatterId?: number;
         date?: Date;
         amount?: number;
         description?: string | null;
     }): Promise<EmployeeEarningModel | null>;
-    delete(id: number): Promise<void>;
+    delete(id: string): Promise<void>;
 }

--- a/src/data/interfaces/IModelRepository.ts
+++ b/src/data/interfaces/IModelRepository.ts
@@ -1,0 +1,9 @@
+import {ModelModel} from "../../business/models/ModelModel";
+
+export interface IModelRepository {
+    findAll(): Promise<ModelModel[]>;
+    findById(id: number): Promise<ModelModel | null>;
+    create(data: { displayName: string; username: string; commissionRate: number; }): Promise<ModelModel>;
+    update(id: number, data: { displayName?: string; username?: string; commissionRate?: number; }): Promise<ModelModel | null>;
+    delete(id: number): Promise<void>;
+}

--- a/src/data/interfaces/IShiftRepository.ts
+++ b/src/data/interfaces/IShiftRepository.ts
@@ -6,6 +6,7 @@ export interface IShiftRepository {
     findById(id: number): Promise<ShiftModel | null>;
     create(data: {
         chatterId: number;
+        modelId: number;
         date: Date;
         start_time: Date;
         end_time?: Date | null;
@@ -13,6 +14,7 @@ export interface IShiftRepository {
     }): Promise<ShiftModel>;
     update(id: number, data: {
         chatterId?: number;
+        modelId?: number;
         date?: Date;
         start_time?: Date;
         end_time?: Date | null;

--- a/src/data/interfaces/IShiftRepository.ts
+++ b/src/data/interfaces/IShiftRepository.ts
@@ -6,7 +6,7 @@ export interface IShiftRepository {
     findById(id: number): Promise<ShiftModel | null>;
     create(data: {
         chatterId: number;
-        modelId: number;
+        modelIds: number[];
         date: Date;
         start_time: Date;
         end_time?: Date | null;
@@ -14,7 +14,7 @@ export interface IShiftRepository {
     }): Promise<ShiftModel>;
     update(id: number, data: {
         chatterId?: number;
-        modelId?: number;
+        modelIds?: number[];
         date?: Date;
         start_time?: Date;
         end_time?: Date | null;

--- a/src/data/interfaces/IShiftRepository.ts
+++ b/src/data/interfaces/IShiftRepository.ts
@@ -22,5 +22,6 @@ export interface IShiftRepository {
     }): Promise<ShiftModel | null>;
     delete(id: number): Promise<void>;
     findShiftForChatterAt(chatterId: number, datetime: Date): Promise<ShiftModel | null>;
+    findShiftForModelAt(modelId: number, datetime: Date): Promise<ShiftModel | null>;
     getActiveTimeEntry(chatterId: number): Promise<ShiftModel | null>;
 }

--- a/src/data/interfaces/IShiftRepository.ts
+++ b/src/data/interfaces/IShiftRepository.ts
@@ -19,5 +19,6 @@ export interface IShiftRepository {
         status?: ShiftStatus;
     }): Promise<ShiftModel | null>;
     delete(id: number): Promise<void>;
+    findShiftForChatterAt(chatterId: number, datetime: Date): Promise<ShiftModel | null>;
     getActiveTimeEntry(chatterId: number): Promise<ShiftModel | null>;
 }

--- a/src/data/repositories/ChatterRepository.ts
+++ b/src/data/repositories/ChatterRepository.ts
@@ -21,6 +21,14 @@ export class ChatterRepository extends BaseRepository implements IChatterReposit
         return rows.length ? ChatterModel.fromRow(rows[0]) : null;
     }
 
+    public async findByEmail(email: string): Promise<ChatterModel | null> {
+        const rows = await this.execute<RowDataPacket[]>(
+            "SELECT id, email, currency, commission_rate, platform_fee, status, created_at FROM chatters WHERE email = ?",
+            [email]
+        );
+        return rows.length ? ChatterModel.fromRow(rows[0]) : null;
+    }
+
     public async create(data: {userId: number, email: string; currency: CurrencySymbol; commissionRate: number; platformFeeRate: number; status: ChatterStatus; }): Promise<ChatterModel> {
         const result = await this.execute<ResultSetHeader>(
             "INSERT INTO chatters (id, email, currency, commission_rate, platform_fee, status) VALUES (?, ?, ?, ?, ?, ?)",

--- a/src/data/repositories/EmployeeEarningRepository.ts
+++ b/src/data/repositories/EmployeeEarningRepository.ts
@@ -12,7 +12,7 @@ export class EmployeeEarningRepository extends BaseRepository implements IEmploy
         return rows.map(EmployeeEarningModel.fromRow);
     }
 
-    public async findById(id: number): Promise<EmployeeEarningModel | null> {
+    public async findById(id: string): Promise<EmployeeEarningModel | null> {
         const rows = await this.execute<RowDataPacket[]>(
             "SELECT id, chatter_id, date, amount, description, created_at FROM employee_earnings WHERE id = ?",
             [id]
@@ -20,18 +20,28 @@ export class EmployeeEarningRepository extends BaseRepository implements IEmploy
         return rows.length ? EmployeeEarningModel.fromRow(rows[0]) : null;
     }
 
-    public async create(data: { chatterId: number; date: Date; amount: number; description?: string | null; }): Promise<EmployeeEarningModel> {
+    public async create(data: { id?: string; chatterId: number; date: Date; amount: number; description?: string | null; }): Promise<EmployeeEarningModel> {
+        if (data.id) {
+            await this.execute<ResultSetHeader>(
+                "INSERT INTO employee_earnings (id, chatter_id, date, amount, description) VALUES (?, ?, ?, ?, ?)",
+                [data.id, data.chatterId, data.date, data.amount, data.description ?? null]
+            );
+            const created = await this.findById(data.id);
+            if (!created) throw new Error("Failed to fetch created earning");
+            return created;
+        }
+
         const result = await this.execute<ResultSetHeader>(
             "INSERT INTO employee_earnings (chatter_id, date, amount, description) VALUES (?, ?, ?, ?)",
             [data.chatterId, data.date, data.amount, data.description ?? null]
         );
-        const insertedId = Number(result.insertId);
+        const insertedId = String(result.insertId);
         const created = await this.findById(insertedId);
         if (!created) throw new Error("Failed to fetch created earning");
         return created;
     }
 
-    public async update(id: number, data: { chatterId?: number; date?: Date; amount?: number; description?: string | null; }): Promise<EmployeeEarningModel | null> {
+    public async update(id: string, data: { chatterId?: number; date?: Date; amount?: number; description?: string | null; }): Promise<EmployeeEarningModel | null> {
         const existing = await this.findById(id);
         if (!existing) return null;
         await this.execute<ResultSetHeader>(
@@ -47,7 +57,7 @@ export class EmployeeEarningRepository extends BaseRepository implements IEmploy
         return this.findById(id);
     }
 
-    public async delete(id: number): Promise<void> {
+    public async delete(id: string): Promise<void> {
         await this.execute<ResultSetHeader>(
             "DELETE FROM employee_earnings WHERE id = ?",
             [id]

--- a/src/data/repositories/EmployeeEarningRepository.ts
+++ b/src/data/repositories/EmployeeEarningRepository.ts
@@ -63,4 +63,12 @@ export class EmployeeEarningRepository extends BaseRepository implements IEmploy
             [id]
         );
     }
+
+    public async getLastId(): Promise<string | null> {
+        const rows = await this.execute<RowDataPacket[]>(
+            "SELECT id FROM employee_earnings WHERE description LIKE 'F2F%' ORDER BY created_at DESC LIMIT 1",
+            []
+        );
+        return rows.length ? String(rows[0].id) : null;
+    }
 }

--- a/src/data/repositories/ModelRepository.ts
+++ b/src/data/repositories/ModelRepository.ts
@@ -1,0 +1,55 @@
+import {BaseRepository} from "./BaseRepository";
+import {IModelRepository} from "../interfaces/IModelRepository";
+import {ModelModel} from "../../business/models/ModelModel";
+import {ResultSetHeader, RowDataPacket} from "mysql2";
+
+export class ModelRepository extends BaseRepository implements IModelRepository {
+    public async findAll(): Promise<ModelModel[]> {
+        const rows = await this.execute<RowDataPacket[]>(
+            "SELECT id, display_name, username, commission_rate, created_at FROM models",
+            []
+        );
+        return rows.map(ModelModel.fromRow);
+    }
+
+    public async findById(id: number): Promise<ModelModel | null> {
+        const rows = await this.execute<RowDataPacket[]>(
+            "SELECT id, display_name, username, commission_rate, created_at FROM models WHERE id = ?",
+            [id]
+        );
+        return rows.length ? ModelModel.fromRow(rows[0]) : null;
+    }
+
+    public async create(data: { displayName: string; username: string; commissionRate: number; }): Promise<ModelModel> {
+        const result = await this.execute<ResultSetHeader>(
+            "INSERT INTO models (display_name, username, commission_rate) VALUES (?, ?, ?)",
+            [data.displayName, data.username, data.commissionRate]
+        );
+        const insertedId = Number(result.insertId);
+        const created = await this.findById(insertedId);
+        if (!created) throw new Error("Failed to fetch created model");
+        return created;
+    }
+
+    public async update(id: number, data: { displayName?: string; username?: string; commissionRate?: number; }): Promise<ModelModel | null> {
+        const existing = await this.findById(id);
+        if (!existing) return null;
+        await this.execute<ResultSetHeader>(
+            "UPDATE models SET display_name = ?, username = ?, commission_rate = ? WHERE id = ?",
+            [
+                data.displayName ?? existing.displayName,
+                data.username ?? existing.username,
+                data.commissionRate ?? existing.commissionRate,
+                id
+            ]
+        );
+        return this.findById(id);
+    }
+
+    public async delete(id: number): Promise<void> {
+        await this.execute<ResultSetHeader>(
+            "DELETE FROM models WHERE id = ?",
+            [id]
+        );
+    }
+}

--- a/src/data/repositories/ShiftRepository.ts
+++ b/src/data/repositories/ShiftRepository.ts
@@ -7,7 +7,11 @@ import {ResultSetHeader, RowDataPacket} from "mysql2";
 export class ShiftRepository extends BaseRepository implements IShiftRepository {
     public async findAll(): Promise<ShiftModel[]> {
         const rows = await this.execute<RowDataPacket[]>(
-            "SELECT id, chatter_id, model_id, date, start_time, end_time, status, created_at FROM shifts",
+            `SELECT s.id, s.chatter_id, s.date, s.start_time, s.end_time, s.status, s.created_at,
+                    GROUP_CONCAT(sm.model_id) AS model_ids
+               FROM shifts s
+               LEFT JOIN shift_models sm ON sm.shift_id = s.id
+               GROUP BY s.id`,
             []
         );
         return rows.map(ShiftModel.fromRow);
@@ -15,31 +19,43 @@ export class ShiftRepository extends BaseRepository implements IShiftRepository 
 
     public async findById(id: number): Promise<ShiftModel | null> {
         const rows = await this.execute<RowDataPacket[]>(
-            "SELECT id, chatter_id, model_id, date, start_time, end_time, status, created_at FROM shifts WHERE id = ?",
+            `SELECT s.id, s.chatter_id, s.date, s.start_time, s.end_time, s.status, s.created_at,
+                    GROUP_CONCAT(sm.model_id) AS model_ids
+               FROM shifts s
+               LEFT JOIN shift_models sm ON sm.shift_id = s.id
+               WHERE s.id = ?
+               GROUP BY s.id`,
             [id]
         );
         return rows.length ? ShiftModel.fromRow(rows[0]) : null;
     }
 
-    public async create(data: { chatterId: number; modelId: number; date: Date; start_time: Date; end_time?: Date | null; status: ShiftStatus; }): Promise<ShiftModel> {
+    public async create(data: { chatterId: number; modelIds: number[]; date: Date; start_time: Date; end_time?: Date | null; status: ShiftStatus; }): Promise<ShiftModel> {
         const result = await this.execute<ResultSetHeader>(
-            "INSERT INTO shifts (chatter_id, model_id, date, start_time, end_time, status) VALUES (?, ?, ?, ?, ?, ?)",
-            [data.chatterId, data.modelId, data.date, data.start_time, data.end_time ?? null, data.status]
+            "INSERT INTO shifts (chatter_id, date, start_time, end_time, status) VALUES (?, ?, ?, ?, ?)",
+            [data.chatterId, data.date, data.start_time, data.end_time ?? null, data.status]
         );
         const insertedId = Number(result.insertId);
+        if (data.modelIds && data.modelIds.length) {
+            for (const mid of data.modelIds) {
+                await this.execute<ResultSetHeader>(
+                    "INSERT INTO shift_models (shift_id, model_id) VALUES (?, ?)",
+                    [insertedId, mid]
+                );
+            }
+        }
         const created = await this.findById(insertedId);
         if (!created) throw new Error("Failed to fetch created shift");
         return created;
     }
 
-    public async update(id: number, data: { chatterId?: number; modelId?: number; date?: Date; start_time?: Date; end_time?: Date | null; status?: ShiftStatus; }): Promise<ShiftModel | null> {
+    public async update(id: number, data: { chatterId?: number; modelIds?: number[]; date?: Date; start_time?: Date; end_time?: Date | null; status?: ShiftStatus; }): Promise<ShiftModel | null> {
         const existing = await this.findById(id);
         if (!existing) return null;
         await this.execute<ResultSetHeader>(
-            "UPDATE shifts SET chatter_id = ?, model_id = ?, date = ?, start_time = ?, end_time = ?, status = ? WHERE id = ?",
+            "UPDATE shifts SET chatter_id = ?, date = ?, start_time = ?, end_time = ?, status = ? WHERE id = ?",
             [
                 data.chatterId ?? existing.chatterId,
-                data.modelId ?? existing.modelId,
                 data.date ?? existing.date,
                 data.start_time ?? existing.startTime,
                 data.end_time ?? existing.endTime,
@@ -47,22 +63,29 @@ export class ShiftRepository extends BaseRepository implements IShiftRepository 
                 id
             ]
         );
+        if (data.modelIds) {
+            await this.execute<ResultSetHeader>("DELETE FROM shift_models WHERE shift_id = ?", [id]);
+            for (const mid of data.modelIds) {
+                await this.execute<ResultSetHeader>("INSERT INTO shift_models (shift_id, model_id) VALUES (?, ?)", [id, mid]);
+            }
+        }
         return this.findById(id);
     }
 
     public async delete(id: number): Promise<void> {
-        await this.execute<ResultSetHeader>(
-            "DELETE FROM shifts WHERE id = ?",
-            [id]
-        );
+        await this.execute<ResultSetHeader>("DELETE FROM shift_models WHERE shift_id = ?", [id]);
+        await this.execute<ResultSetHeader>("DELETE FROM shifts WHERE id = ?", [id]);
     }
 
     public async findShiftForChatterAt(chatterId: number, datetime: Date): Promise<ShiftModel | null> {
         const rows = await this.execute<RowDataPacket[]>(
-            `SELECT id, chatter_id, date, start_time, end_time, status, created_at
-                 FROM shifts
-                 WHERE chatter_id = ? AND start_time <= ? AND (end_time IS NULL OR end_time >= ?)
-                 ORDER BY start_time DESC LIMIT 1`,
+            `SELECT s.id, s.chatter_id, s.date, s.start_time, s.end_time, s.status, s.created_at,
+                    GROUP_CONCAT(sm.model_id) AS model_ids
+               FROM shifts s
+               LEFT JOIN shift_models sm ON sm.shift_id = s.id
+               WHERE s.chatter_id = ? AND s.start_time <= ? AND (s.end_time IS NULL OR s.end_time >= ?)
+               GROUP BY s.id
+               ORDER BY s.start_time DESC LIMIT 1`,
             [chatterId, datetime, datetime]
         );
         return rows.length ? ShiftModel.fromRow(rows[0]) : null;
@@ -70,10 +93,14 @@ export class ShiftRepository extends BaseRepository implements IShiftRepository 
 
     public async findShiftForModelAt(modelId: number, datetime: Date): Promise<ShiftModel | null> {
         const rows = await this.execute<RowDataPacket[]>(
-            `SELECT id, chatter_id, model_id, date, start_time, end_time, status, created_at
-                 FROM shifts
-                 WHERE model_id = ? AND start_time <= ? AND (end_time IS NULL OR end_time >= ?)
-                 ORDER BY start_time DESC LIMIT 1`,
+            `SELECT s.id, s.chatter_id, s.date, s.start_time, s.end_time, s.status, s.created_at,
+                    GROUP_CONCAT(sm.model_id) AS model_ids
+               FROM shifts s
+               JOIN shift_models sm1 ON sm1.shift_id = s.id AND sm1.model_id = ?
+               LEFT JOIN shift_models sm ON sm.shift_id = s.id
+               WHERE s.start_time <= ? AND (s.end_time IS NULL OR s.end_time >= ?)
+               GROUP BY s.id
+               ORDER BY s.start_time DESC LIMIT 1`,
             [modelId, datetime, datetime]
         );
         return rows.length ? ShiftModel.fromRow(rows[0]) : null;
@@ -81,10 +108,13 @@ export class ShiftRepository extends BaseRepository implements IShiftRepository 
 
     public getActiveTimeEntry(chatterId: number): Promise<ShiftModel | null> {
         return this.execute<RowDataPacket[]>(
-            `SELECT id, chatter_id, model_id, date, start_time, end_time, status, created_at
-                 FROM shifts
-                 WHERE chatter_id = ? AND status IN ('active','scheduled')
-                 ORDER BY start_time DESC LIMIT 1;`,
+            `SELECT s.id, s.chatter_id, s.date, s.start_time, s.end_time, s.status, s.created_at,
+                    GROUP_CONCAT(sm.model_id) AS model_ids
+               FROM shifts s
+               LEFT JOIN shift_models sm ON sm.shift_id = s.id
+               WHERE s.chatter_id = ? AND s.status IN ('active','scheduled')
+               GROUP BY s.id
+               ORDER BY s.start_time DESC LIMIT 1;`,
             [chatterId]
         ).then(rows => rows.length ? ShiftModel.fromRow(rows[0]) : null);
     }

--- a/src/data/repositories/ShiftRepository.ts
+++ b/src/data/repositories/ShiftRepository.ts
@@ -56,9 +56,20 @@ export class ShiftRepository extends BaseRepository implements IShiftRepository 
         );
     }
 
+    public async findShiftForChatterAt(chatterId: number, datetime: Date): Promise<ShiftModel | null> {
+        const rows = await this.execute<RowDataPacket[]>(
+            `SELECT id, chatter_id, date, start_time, end_time, status, created_at
+                 FROM shifts
+                 WHERE chatter_id = ? AND start_time <= ? AND (end_time IS NULL OR end_time >= ?)
+                 ORDER BY start_time DESC LIMIT 1`,
+            [chatterId, datetime, datetime]
+        );
+        return rows.length ? ShiftModel.fromRow(rows[0]) : null;
+    }
+
     public getActiveTimeEntry(chatterId: number): Promise<ShiftModel | null> {
         return this.execute<RowDataPacket[]>(
-            `SELECT id, chatter_id, date, start_time, end_time, status, created_at 
+            `SELECT id, chatter_id, date, start_time, end_time, status, created_at
                  FROM shifts
                  WHERE chatter_id = ? AND status IN ('active','scheduled')
                  ORDER BY start_time DESC LIMIT 1;`,

--- a/src/data/repositories/ShiftRepository.ts
+++ b/src/data/repositories/ShiftRepository.ts
@@ -68,6 +68,17 @@ export class ShiftRepository extends BaseRepository implements IShiftRepository 
         return rows.length ? ShiftModel.fromRow(rows[0]) : null;
     }
 
+    public async findShiftForModelAt(modelId: number, datetime: Date): Promise<ShiftModel | null> {
+        const rows = await this.execute<RowDataPacket[]>(
+            `SELECT id, chatter_id, model_id, date, start_time, end_time, status, created_at
+                 FROM shifts
+                 WHERE model_id = ? AND start_time <= ? AND (end_time IS NULL OR end_time >= ?)
+                 ORDER BY start_time DESC LIMIT 1`,
+            [modelId, datetime, datetime]
+        );
+        return rows.length ? ShiftModel.fromRow(rows[0]) : null;
+    }
+
     public getActiveTimeEntry(chatterId: number): Promise<ShiftModel | null> {
         return this.execute<RowDataPacket[]>(
             `SELECT id, chatter_id, model_id, date, start_time, end_time, status, created_at

--- a/src/routes/EmployeeEarningRoute.ts
+++ b/src/routes/EmployeeEarningRoute.ts
@@ -5,10 +5,12 @@ import {EmployeeEarningController} from "../controllers/EmployeeEarningControlle
 const router = Router();
 const controller = new EmployeeEarningController();
 
-router.get("/", authenticateToken, controller.getAll.bind(controller));
-router.get("/:id", authenticateToken, controller.getById.bind(controller));
-router.post("/", authenticateToken, controller.create.bind(controller));
-router.put("/:id", authenticateToken, controller.update.bind(controller));
-router.delete("/:id", authenticateToken, controller.delete.bind(controller));
+router.use(authenticateToken);
+
+router.get("/", controller.getAll.bind(controller));
+router.get("/:id", controller.getById.bind(controller));
+router.post("/", controller.create.bind(controller));
+router.put("/:id", controller.update.bind(controller));
+router.delete("/:id", controller.delete.bind(controller));
 
 export default router;

--- a/src/routes/ModelRoute.ts
+++ b/src/routes/ModelRoute.ts
@@ -1,0 +1,14 @@
+import {Router} from "express";
+import {authenticateToken} from "../middleware/auth";
+import {ModelController} from "../controllers/ModelController";
+
+const router = Router();
+const controller = new ModelController();
+
+router.get("/", authenticateToken, controller.getAll.bind(controller));
+router.get("/:id", authenticateToken, controller.getById.bind(controller));
+router.post("/", authenticateToken, controller.create.bind(controller));
+router.put("/:id", authenticateToken, controller.update.bind(controller));
+router.delete("/:id", authenticateToken, controller.delete.bind(controller));
+
+export default router;

--- a/src/server.ts
+++ b/src/server.ts
@@ -21,7 +21,6 @@ const allowedOrigins = [
 
 const corsOptions: cors.CorsOptions = {
     origin: (origin, callback) => {
-        console.log("Request origin:", origin); // Log the incoming origin
         // Allow requests with no origin (like mobile apps or curl requests)
         if (!origin) return callback(null, true);
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -5,6 +5,7 @@ import userRoute from "./routes/UserRoute";
 import chatterRoute from "./routes/ChatterRoute";
 import employeeEarningRoute from "./routes/EmployeeEarningRoute";
 import shiftRoute from "./routes/ShiftRoute";
+import modelRoute from "./routes/ModelRoute";
 
 import cors from "cors";
 
@@ -52,6 +53,7 @@ app.use("/api/users", userRoute);
 app.use("/api/chatters", chatterRoute);
 app.use("/api/employee-earnings", employeeEarningRoute);
 app.use("/api/shifts", shiftRoute);
+app.use("/api/models", modelRoute);
 
 // Health
 app.get("/api/health", (_req, res) => res.json({ ok: true }));

--- a/src/tasks/syncTransactionEarnings.ts
+++ b/src/tasks/syncTransactionEarnings.ts
@@ -13,7 +13,7 @@ runOnce().catch(err => {
   process.exit(1);
 });
 
-const INTERVAL_MS = 60 * 1000;
+const INTERVAL_MS = 60 * 60 * 1000;
 setInterval(() => {
   runOnce().catch(err => console.error('Sync failed', err));
 }, INTERVAL_MS);

--- a/src/tasks/syncTransactionEarnings.ts
+++ b/src/tasks/syncTransactionEarnings.ts
@@ -1,0 +1,19 @@
+import 'reflect-metadata';
+import '../container';
+import {container} from 'tsyringe';
+import {F2FTransactionSyncService} from '../business/services/F2FTransactionSyncService';
+
+async function runOnce() {
+  const svc = container.resolve(F2FTransactionSyncService);
+  await svc.syncRecentPayPerMessage();
+}
+
+runOnce().catch(err => {
+  console.error('Sync failed', err);
+  process.exit(1);
+});
+
+const INTERVAL_MS = 60 * 1000;
+setInterval(() => {
+  runOnce().catch(err => console.error('Sync failed', err));
+}, INTERVAL_MS);

--- a/src/tasks/syncUnlockEarnings.ts
+++ b/src/tasks/syncUnlockEarnings.ts
@@ -1,0 +1,19 @@
+import 'reflect-metadata';
+import '../container';
+import {container} from 'tsyringe';
+import {F2FUnlockSyncService} from '../business/services/F2FUnlockSyncService';
+
+async function runOnce() {
+  const svc = container.resolve(F2FUnlockSyncService);
+  await svc.syncLast24Hours();
+}
+
+runOnce().catch(err => {
+  console.error('Sync failed', err);
+  process.exit(1);
+});
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+setInterval(() => {
+  runOnce().catch(err => console.error('Sync failed', err));
+}, DAY_MS);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     "module": "CommonJS",
     "rootDir": "./src",
     "outDir": "./build",
-    "lib": ["ES2020"],                      // include whatever ES libs you need
+    "lib": ["ES2020", "DOM"],                      // include whatever ES libs you need
     "strict": true,                         // optional, but recommended
     "esModuleInterop": true,
     "skipLibCheck": true,


### PR DESCRIPTION
## Summary
- add service to fetch F2F chat unlocks and store earnings for active shifts
- support finding chatters by email and locating shifts at a specific time
- include task script and container binding to run sync every 24 hours

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm test` *(fails: jest not installed)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b6f275bcac832787895e668659c865