### PR TITLE
Add F2F unlock earnings sync

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
     "start": "node build/server.js",
     "dev": "ts-node-dev --files --transpile-only --respawn --inspect=4321 --project tsconfig.json src/server.ts",
     "lint": "eslint 'src/**/*.ts'",
-    "test": "jest"
+    "test": "jest",
+    "sync:earnings": "ts-node src/tasks/syncUnlockEarnings.ts"
   },
   "dependencies": {
     "@vercel/node": "^5.3.15",

--- a/src/business/models/ModelModel.ts
+++ b/src/business/models/ModelModel.ts
@@ -1,0 +1,23 @@
+export class ModelModel {
+    constructor(
+        private _id: number,
+        private _username: string,
+    ) {}
+
+    public toJSON(): Record<string, any> {
+        return {
+            id: this.id,
+            username: this.username,
+        };
+    }
+
+    get id(): number { return this._id; }
+    get username(): string { return this._username; }
+
+    static fromRow(r: any): ModelModel {
+        return new ModelModel(
+            Number(r.id),
+            String(r.username),
+        );
+    }
+}

--- a/src/business/services/F2FUnlockSyncService.ts
+++ b/src/business/services/F2FUnlockSyncService.ts
@@ -1,0 +1,163 @@
+import {inject, injectable} from "tsyringe";
+import {IChatterRepository} from "../../data/interfaces/IChatterRepository";
+import {IShiftRepository} from "../../data/interfaces/IShiftRepository";
+import {IEmployeeEarningRepository} from "../../data/interfaces/IEmployeeEarningRepository";
+import {IModelRepository} from "../../data/interfaces/IModelRepository";
+
+const BASE = process.env.F2F_BASE || "https://f2f.com";
+const UA = process.env.UA ||
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36";
+const COOKIES = process.env.F2F_COOKIES || "";
+
+const sleep = (ms: number) => new Promise(res => setTimeout(res, ms));
+
+@injectable()
+export class F2FUnlockSyncService {
+    constructor(
+        @inject("IChatterRepository") private chatterRepo: IChatterRepository,
+        @inject("IShiftRepository") private shiftRepo: IShiftRepository,
+        @inject("IEmployeeEarningRepository") private earningRepo: IEmployeeEarningRepository,
+        @inject("IModelRepository") private modelRepo: IModelRepository,
+    ) {}
+
+    private headersFor(creatorSlug?: string): Record<string, string> {
+        const h: Record<string, string> = {
+            accept: "application/json, text/plain, */*",
+            "accept-language": "nl-NL,nl;q=0.9,en-US;q=0.8,en;q=0.7",
+            "user-agent": UA,
+            cookie: COOKIES,
+            origin: BASE,
+            referer: `${BASE}/`,
+        };
+        if (creatorSlug) h["impersonate-user"] = creatorSlug;
+        return h;
+    }
+
+
+    private async getAllChatsForCreator(creator: string, fromDate: Date, toDate: Date): Promise<any[]> {
+        let url: string | null = `${BASE}/api/chats/?ordering=newest-first`;
+        const headers = this.headersFor(creator);
+        const all: any[] = [];
+        const seen = new Set<string>();
+
+        while (url) {
+            if (seen.has(url)) break;
+            seen.add(url);
+
+            const res = await fetch(url, {headers});
+            const ct = res.headers.get("content-type") || "";
+            const text = await res.text();
+
+            if (!res.ok || ct.includes("text/html")) {
+                throw new Error(`[chats:${creator}] Blocked/error ${res.status}. First 300 chars:\n${text.slice(0, 300)}`);
+            }
+
+            const page = JSON.parse(text);
+            const items = Array.isArray(page) ? page : page.results || [];
+            all.push(...items);
+
+            const last = items[items.length - 1];
+            const lastDt = last?.message?.datetime;
+            if (!lastDt || new Date(lastDt) < fromDate) {
+                break;
+            }
+
+            url = page.next || null;
+            if (url) await sleep(120);
+        }
+
+        const inWindow = (iso: string) => {
+            if (!iso) return false;
+            const d = new Date(iso);
+            return !Number.isNaN(d.getTime()) && d >= fromDate && d <= toDate;
+        };
+
+        return all
+            .filter((c: any) => inWindow(c.message?.datetime))
+            .map((c: any) => ({
+                id: c.uuid || c.id,
+                title: c.title || "",
+                username: c.other_user?.username || null,
+                lastMessageAt: c.message?.datetime || null,
+            }))
+            .filter((c: any) => !!c.id);
+    }
+
+    private async getAllMessagesForChat(creator: string, chatId: string, fromDate: Date): Promise<any[]> {
+        let url: string | null = `${BASE}/api/chats/${chatId}/messages/`;
+        const headers = this.headersFor(creator);
+        const all: any[] = [];
+        const seen = new Set<string>();
+
+        while (url) {
+            if (seen.has(url)) break;
+            seen.add(url);
+
+            const res = await fetch(url, {headers});
+            const ct = res.headers.get("content-type") || "";
+            const text = await res.text();
+
+            if (!res.ok || ct.includes("text/html")) {
+                throw new Error(`[msgs:${creator}:${chatId}] Blocked/error ${res.status}. First 300 chars:\n${text.slice(0, 300)}`);
+            }
+
+            const page = JSON.parse(text);
+            const items = Array.isArray(page) ? page : page.results || [];
+            all.push(...items);
+
+            const last = items[items.length - 1];
+            const lastDt = last?.datetime;
+            if (!lastDt || new Date(lastDt) < fromDate) {
+                break;
+            }
+
+            url = page.next || null;
+            if (url) await sleep(120);
+        }
+
+        return all;
+    }
+
+    private pickUnlocksInWindow(messages: any[], fromDate: Date, toDate: Date): {datetime: string, price: number}[] {
+        return messages
+            .filter(m =>
+                m.unlock &&
+                typeof m.unlock.price !== "undefined" &&
+                m.datetime &&
+                new Date(m.datetime) >= fromDate &&
+                new Date(m.datetime) <= toDate
+            )
+            .map(m => ({ datetime: m.datetime, price: Number(m.unlock.price) || 0 }));
+    }
+
+    public async syncLast24Hours(): Promise<void> {
+        if (!COOKIES) {
+            throw new Error("F2F_COOKIES env var required");
+        }
+        const now = new Date();
+        const from = new Date(now.getTime() - 24 * 60 * 60 * 1000);
+        const models = await this.modelRepo.findAll();
+        for (const model of models) {
+            const creator = model.username;
+            const chatter = await this.chatterRepo.findByEmail(creator);
+            if (!chatter) continue;
+            const chats = await this.getAllChatsForCreator(creator, from, now);
+            for (const chat of chats) {
+                const msgs = await this.getAllMessagesForChat(creator, chat.id, from);
+                const unlocks = this.pickUnlocksInWindow(msgs, from, now);
+                for (const u of unlocks) {
+                    const ts = new Date(u.datetime);
+                    const shift = await this.shiftRepo.findShiftForChatterAt(chatter.id, ts);
+                    if (!shift) continue;
+                    await this.earningRepo.create({
+                        chatterId: chatter.id,
+                        date: shift.date,
+                        amount: u.price,
+                        description: `unlock:${chat.id}:${u.datetime}`,
+                    });
+                }
+                await sleep(100);
+            }
+        }
+    }
+}

--- a/src/container/index.ts
+++ b/src/container/index.ts
@@ -14,6 +14,9 @@ import {ShiftRepository} from "../data/repositories/ShiftRepository";
 import {CommissionService} from "../business/services/CommissionService";
 import {ICommissionRepository} from "../data/interfaces/ICommissionRepository";
 import {CommissionRepository} from "../data/repositories/CommissionRepository";
+import {F2FUnlockSyncService} from "../business/services/F2FUnlockSyncService";
+import {IModelRepository} from "../data/interfaces/IModelRepository";
+import {ModelRepository} from "../data/repositories/ModelRepository";
 
 container.register("UserService", { useClass: UserService });
 
@@ -40,3 +43,5 @@ container.register("CommissionService", { useClass: CommissionService });
 container.register<ICommissionRepository>("ICommissionRepository", {
     useClass: CommissionRepository,
 });
+container.register<IModelRepository>("IModelRepository", { useClass: ModelRepository });
+container.register("F2FUnlockSyncService", { useClass: F2FUnlockSyncService });

--- a/src/data/interfaces/IChatterRepository.ts
+++ b/src/data/interfaces/IChatterRepository.ts
@@ -4,6 +4,7 @@ import {ChatterStatus, CurrencySymbol} from "../../rename/types";
 export interface IChatterRepository {
     findAll(): Promise<ChatterModel[]>;
     findById(id: number): Promise<ChatterModel | null>;
+    findByEmail(email: string): Promise<ChatterModel | null>;
     create(data: {
         userId: number;
         email: string;

--- a/src/data/interfaces/IModelRepository.ts
+++ b/src/data/interfaces/IModelRepository.ts
@@ -1,0 +1,6 @@
+import {ModelModel} from "../../business/models/ModelModel";
+
+export interface IModelRepository {
+    findAll(): Promise<ModelModel[]>;
+    findByUsername(username: string): Promise<ModelModel | null>;
+}

--- a/src/data/interfaces/IShiftRepository.ts
+++ b/src/data/interfaces/IShiftRepository.ts
@@ -19,5 +19,6 @@ export interface IShiftRepository {
         status?: ShiftStatus;
     }): Promise<ShiftModel | null>;
     delete(id: number): Promise<void>;
+    findShiftForChatterAt(chatterId: number, datetime: Date): Promise<ShiftModel | null>;
     getActiveTimeEntry(chatterId: number): Promise<ShiftModel | null>;
 }

--- a/src/data/repositories/ChatterRepository.ts
+++ b/src/data/repositories/ChatterRepository.ts
@@ -21,6 +21,14 @@ export class ChatterRepository extends BaseRepository implements IChatterReposit
         return rows.length ? ChatterModel.fromRow(rows[0]) : null;
     }
 
+    public async findByEmail(email: string): Promise<ChatterModel | null> {
+        const rows = await this.execute<RowDataPacket[]>(
+            "SELECT id, email, currency, commission_rate, platform_fee, status, created_at FROM chatters WHERE email = ?",
+            [email]
+        );
+        return rows.length ? ChatterModel.fromRow(rows[0]) : null;
+    }
+
     public async create(data: {userId: number, email: string; currency: CurrencySymbol; commissionRate: number; platformFeeRate: number; status: ChatterStatus; }): Promise<ChatterModel> {
         const result = await this.execute<ResultSetHeader>(
             "INSERT INTO chatters (id, email, currency, commission_rate, platform_fee, status) VALUES (?, ?, ?, ?, ?, ?)",

--- a/src/data/repositories/ModelRepository.ts
+++ b/src/data/repositories/ModelRepository.ts
@@ -1,0 +1,22 @@
+import {BaseRepository} from "./BaseRepository";
+import {IModelRepository} from "../interfaces/IModelRepository";
+import {ModelModel} from "../../business/models/ModelModel";
+import {RowDataPacket} from "mysql2";
+
+export class ModelRepository extends BaseRepository implements IModelRepository {
+    public async findAll(): Promise<ModelModel[]> {
+        const rows = await this.execute<RowDataPacket[]>(
+            "SELECT id, username FROM models",
+            []
+        );
+        return rows.map(ModelModel.fromRow);
+    }
+
+    public async findByUsername(username: string): Promise<ModelModel | null> {
+        const rows = await this.execute<RowDataPacket[]>(
+            "SELECT id, username FROM models WHERE username = ?",
+            [username]
+        );
+        return rows.length ? ModelModel.fromRow(rows[0]) : null;
+    }
+}

--- a/src/data/repositories/ShiftRepository.ts
+++ b/src/data/repositories/ShiftRepository.ts
@@ -56,9 +56,20 @@ export class ShiftRepository extends BaseRepository implements IShiftRepository 
         );
     }
 
+    public async findShiftForChatterAt(chatterId: number, datetime: Date): Promise<ShiftModel | null> {
+        const rows = await this.execute<RowDataPacket[]>(
+            `SELECT id, chatter_id, date, start_time, end_time, status, created_at
+                 FROM shifts
+                 WHERE chatter_id = ? AND start_time <= ? AND (end_time IS NULL OR end_time >= ?)
+                 ORDER BY start_time DESC LIMIT 1`,
+            [chatterId, datetime, datetime]
+        );
+        return rows.length ? ShiftModel.fromRow(rows[0]) : null;
+    }
+
     public getActiveTimeEntry(chatterId: number): Promise<ShiftModel | null> {
         return this.execute<RowDataPacket[]>(
-            `SELECT id, chatter_id, date, start_time, end_time, status, created_at 
+            `SELECT id, chatter_id, date, start_time, end_time, status, created_at
                  FROM shifts
                  WHERE chatter_id = ? AND status IN ('active','scheduled')
                  ORDER BY start_time DESC LIMIT 1;`,

--- a/src/tasks/syncUnlockEarnings.ts
+++ b/src/tasks/syncUnlockEarnings.ts
@@ -1,0 +1,19 @@
+import 'reflect-metadata';
+import '../container';
+import {container} from 'tsyringe';
+import {F2FUnlockSyncService} from '../business/services/F2FUnlockSyncService';
+
+async function runOnce() {
+  const svc = container.resolve(F2FUnlockSyncService);
+  await svc.syncLast24Hours();
+}
+
+runOnce().catch(err => {
+  console.error('Sync failed', err);
+  process.exit(1);
+});
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+setInterval(() => {
+  runOnce().catch(err => console.error('Sync failed', err));
+}, DAY_MS);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     "module": "CommonJS",
     "rootDir": "./src",
     "outDir": "./build",
-    "lib": ["ES2020"],                      // include whatever ES libs you need
+    "lib": ["ES2020", "DOM"],                      // include whatever ES libs you need
     "strict": true,                         // optional, but recommended
     "esModuleInterop": true,
     "skipLibCheck": true,


### PR DESCRIPTION
## Summary
- add service to fetch F2F chat unlocks and store earnings for active shifts
- support finding chatters by email and locating shifts at a specific time
- include task script and container binding to run sync every 24 hours
- limit F2F syncing to models stored in the database
- stop paginating chats and messages once results fall before the sync window to reduce requests

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm test` *(fails: jest not installed)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b6f275bcac832787895e668659c865