### PR TITLE
Prevent duplicate earnings during F2F transaction sync

### DIFF
--- a/src/business/models/EmployeeEarningModel.ts
+++ b/src/business/models/EmployeeEarningModel.ts
@@ -1,6 +1,6 @@
 export class EmployeeEarningModel {
     constructor(
-        private _id: number,
+        private _id: string,
         private _chatterId: number,
         private _date: Date,           // business date
         private _amount: number,       // decimal(10,2)
@@ -20,7 +20,7 @@ export class EmployeeEarningModel {
     }
 
     // Getters
-    get id(): number { return this._id; }
+    get id(): string { return this._id; }
     get chatterId(): number { return this._chatterId; }
     get date(): Date { return this._date; }
     get amount(): number { return this._amount; }
@@ -29,7 +29,7 @@ export class EmployeeEarningModel {
 
     static fromRow(r: any): EmployeeEarningModel {
         return new EmployeeEarningModel(
-            Number(r.id),
+            String(r.id),
             Number(r.chatter_id),
             new Date(r.date),
             Number(r.amount),

--- a/src/business/services/EmployeeEarningService.ts
+++ b/src/business/services/EmployeeEarningService.ts
@@ -15,7 +15,7 @@ export class EmployeeEarningService {
         return this.earningRepo.findAll();
     }
 
-    public async getById(id: number): Promise<EmployeeEarningModel | null> {
+    public async getById(id: string): Promise<EmployeeEarningModel | null> {
         await this.txnSync.syncRecentPayPerMessage().catch(console.error);
         return this.earningRepo.findById(id);
     }
@@ -24,11 +24,11 @@ export class EmployeeEarningService {
         return this.earningRepo.create(data);
     }
 
-    public async update(id: number, data: { chatterId?: number; date?: Date; amount?: number; description?: string | null; }): Promise<EmployeeEarningModel | null> {
+    public async update(id: string, data: { chatterId?: number; date?: Date; amount?: number; description?: string | null; }): Promise<EmployeeEarningModel | null> {
         return this.earningRepo.update(id, data);
     }
 
-    public async delete(id: number): Promise<void> {
+    public async delete(id: string): Promise<void> {
         await this.earningRepo.delete(id);
     }
 }

--- a/src/business/services/F2FTransactionSyncService.ts
+++ b/src/business/services/F2FTransactionSyncService.ts
@@ -85,11 +85,16 @@ export class F2FTransactionSyncService {
             const ts = new Date(detail.created);
             const shift = await this.shiftRepo.findShiftForModelAt(modelId, ts);
             if (!shift) continue;
+            const id = txn.uuid;
+            const description = `paypermessage: ${detail.user}`;
+            const existing = await this.earningRepo.findById(id);
+            if (existing) continue;
             await this.earningRepo.create({
+                id,
                 chatterId: shift.chatterId,
                 date: shift.date,
                 amount: revenue,
-                description: `paypermessage: ${detail.user}`,
+                description,
             });
             await sleep(50);
         }

--- a/src/controllers/EmployeeEarningController.ts
+++ b/src/controllers/EmployeeEarningController.ts
@@ -19,7 +19,7 @@ export class EmployeeEarningController {
 
     public async getById(req: Request, res: Response): Promise<void> {
         try {
-            const id = Number(req.params.id);
+            const id = req.params.id;
             const earning = await this.service.getById(id);
             if (!earning) {
                 res.status(404).send("Earning not found");
@@ -44,7 +44,7 @@ export class EmployeeEarningController {
 
     public async update(req: Request, res: Response): Promise<void> {
         try {
-            const id = Number(req.params.id);
+            const id = req.params.id;
             const earning = await this.service.update(id, req.body);
             if (!earning) {
                 res.status(404).send("Earning not found");
@@ -59,7 +59,7 @@ export class EmployeeEarningController {
 
     public async delete(req: Request, res: Response): Promise<void> {
         try {
-            const id = Number(req.params.id);
+            const id = req.params.id;
             await this.service.delete(id);
             res.sendStatus(204);
         } catch (err) {

--- a/src/data/interfaces/IEmployeeEarningRepository.ts
+++ b/src/data/interfaces/IEmployeeEarningRepository.ts
@@ -2,18 +2,19 @@ import {EmployeeEarningModel} from "../../business/models/EmployeeEarningModel";
 
 export interface IEmployeeEarningRepository {
     findAll(): Promise<EmployeeEarningModel[]>;
-    findById(id: number): Promise<EmployeeEarningModel | null>;
+    findById(id: string): Promise<EmployeeEarningModel | null>;
     create(data: {
+        id?: string;
         chatterId: number;
         date: Date;
         amount: number;
         description?: string | null;
     }): Promise<EmployeeEarningModel>;
-    update(id: number, data: {
+    update(id: string, data: {
         chatterId?: number;
         date?: Date;
         amount?: number;
         description?: string | null;
     }): Promise<EmployeeEarningModel | null>;
-    delete(id: number): Promise<void>;
+    delete(id: string): Promise<void>;
 }

--- a/src/data/repositories/EmployeeEarningRepository.ts
+++ b/src/data/repositories/EmployeeEarningRepository.ts
@@ -12,7 +12,7 @@ export class EmployeeEarningRepository extends BaseRepository implements IEmploy
         return rows.map(EmployeeEarningModel.fromRow);
     }
 
-    public async findById(id: number): Promise<EmployeeEarningModel | null> {
+    public async findById(id: string): Promise<EmployeeEarningModel | null> {
         const rows = await this.execute<RowDataPacket[]>(
             "SELECT id, chatter_id, date, amount, description, created_at FROM employee_earnings WHERE id = ?",
             [id]
@@ -20,18 +20,28 @@ export class EmployeeEarningRepository extends BaseRepository implements IEmploy
         return rows.length ? EmployeeEarningModel.fromRow(rows[0]) : null;
     }
 
-    public async create(data: { chatterId: number; date: Date; amount: number; description?: string | null; }): Promise<EmployeeEarningModel> {
+    public async create(data: { id?: string; chatterId: number; date: Date; amount: number; description?: string | null; }): Promise<EmployeeEarningModel> {
+        if (data.id) {
+            await this.execute<ResultSetHeader>(
+                "INSERT INTO employee_earnings (id, chatter_id, date, amount, description) VALUES (?, ?, ?, ?, ?)",
+                [data.id, data.chatterId, data.date, data.amount, data.description ?? null]
+            );
+            const created = await this.findById(data.id);
+            if (!created) throw new Error("Failed to fetch created earning");
+            return created;
+        }
+
         const result = await this.execute<ResultSetHeader>(
             "INSERT INTO employee_earnings (chatter_id, date, amount, description) VALUES (?, ?, ?, ?)",
             [data.chatterId, data.date, data.amount, data.description ?? null]
         );
-        const insertedId = Number(result.insertId);
+        const insertedId = String(result.insertId);
         const created = await this.findById(insertedId);
         if (!created) throw new Error("Failed to fetch created earning");
         return created;
     }
 
-    public async update(id: number, data: { chatterId?: number; date?: Date; amount?: number; description?: string | null; }): Promise<EmployeeEarningModel | null> {
+    public async update(id: string, data: { chatterId?: number; date?: Date; amount?: number; description?: string | null; }): Promise<EmployeeEarningModel | null> {
         const existing = await this.findById(id);
         if (!existing) return null;
         await this.execute<ResultSetHeader>(
@@ -47,7 +57,7 @@ export class EmployeeEarningRepository extends BaseRepository implements IEmploy
         return this.findById(id);
     }
 
-    public async delete(id: number): Promise<void> {
+    public async delete(id: string): Promise<void> {
         await this.execute<ResultSetHeader>(
             "DELETE FROM employee_earnings WHERE id = ?",
             [id]


### PR DESCRIPTION
## Summary
- key repository ID lookups and insertions now accept custom UUIDs
- use transaction UUID as earning ID during F2F pay-per-message sync

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: ESLint configuration missing)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b945e73da083278de16d42ad4e227c