### PR TITLE
Store F2F transactions without chatter match

### DIFF
--- a/src/business/models/EmployeeEarningModel.ts
+++ b/src/business/models/EmployeeEarningModel.ts
@@ -1,7 +1,7 @@
 export class EmployeeEarningModel {
     constructor(
         private _id: string,
-        private _chatterId: number,
+        private _chatterId: number | null,
         private _date: Date,           // business date
         private _amount: number,       // decimal(10,2)
         private _description: string | null,
@@ -21,7 +21,7 @@ export class EmployeeEarningModel {
 
     // Getters
     get id(): string { return this._id; }
-    get chatterId(): number { return this._chatterId; }
+    get chatterId(): number | null { return this._chatterId; }
     get date(): Date { return this._date; }
     get amount(): number { return this._amount; }
     get description(): string | null { return this._description; }
@@ -30,7 +30,7 @@ export class EmployeeEarningModel {
     static fromRow(r: any): EmployeeEarningModel {
         return new EmployeeEarningModel(
             String(r.id),
-            Number(r.chatter_id),
+            r.chatter_id != null ? Number(r.chatter_id) : null,
             new Date(r.date),
             Number(r.amount),
             r.description != null ? String(r.description) : null,

--- a/src/business/services/F2FTransactionSyncService.ts
+++ b/src/business/services/F2FTransactionSyncService.ts
@@ -104,14 +104,13 @@ export class F2FTransactionSyncService {
             const ts = new Date(detail.created);
             const shift = await this.shiftRepo.findShiftForModelAt(modelId, ts);
             console.log(`  -> model ${creator} id ${modelId}, found shift: ${shift ? shift.id + ' models:' + shift.modelIds.join(',') : 'NO SHIFT'}`);
-            if (!shift) continue;
             const id = txn.uuid;
             const existing = await this.earningRepo.findById(id);
             if (existing) continue;
             await this.earningRepo.create({
                 id,
-                chatterId: shift.chatterId,
-                date: shift.date,
+                chatterId: shift ? shift.chatterId : null,
+                date: shift ? shift.date : ts,
                 amount: revenue,
                 description: `F2F: -User: ${detail.user} - Date:${ts}`,
             });

--- a/src/data/interfaces/IEmployeeEarningRepository.ts
+++ b/src/data/interfaces/IEmployeeEarningRepository.ts
@@ -5,13 +5,13 @@ export interface IEmployeeEarningRepository {
     findById(id: string): Promise<EmployeeEarningModel | null>;
     create(data: {
         id?: string;
-        chatterId: number;
+        chatterId?: number | null;
         date: Date;
         amount: number;
         description?: string | null;
     }): Promise<EmployeeEarningModel>;
     update(id: string, data: {
-        chatterId?: number;
+        chatterId?: number | null;
         date?: Date;
         amount?: number;
         description?: string | null;

--- a/src/data/repositories/EmployeeEarningRepository.ts
+++ b/src/data/repositories/EmployeeEarningRepository.ts
@@ -20,11 +20,11 @@ export class EmployeeEarningRepository extends BaseRepository implements IEmploy
         return rows.length ? EmployeeEarningModel.fromRow(rows[0]) : null;
     }
 
-    public async create(data: { id?: string; chatterId: number; date: Date; amount: number; description?: string | null; }): Promise<EmployeeEarningModel> {
+    public async create(data: { id?: string; chatterId?: number | null; date: Date; amount: number; description?: string | null; }): Promise<EmployeeEarningModel> {
         if (data.id) {
             await this.execute<ResultSetHeader>(
                 "INSERT INTO employee_earnings (id, chatter_id, date, amount, description) VALUES (?, ?, ?, ?, ?)",
-                [data.id, data.chatterId, data.date, data.amount, data.description ?? null]
+                [data.id, data.chatterId ?? null, data.date, data.amount, data.description ?? null]
             );
             const created = await this.findById(data.id);
             if (!created) throw new Error("Failed to fetch created earning");
@@ -33,7 +33,7 @@ export class EmployeeEarningRepository extends BaseRepository implements IEmploy
 
         const result = await this.execute<ResultSetHeader>(
             "INSERT INTO employee_earnings (chatter_id, date, amount, description) VALUES (?, ?, ?, ?)",
-            [data.chatterId, data.date, data.amount, data.description ?? null]
+            [data.chatterId ?? null, data.date, data.amount, data.description ?? null]
         );
         const insertedId = String(result.insertId);
         const created = await this.findById(insertedId);
@@ -41,13 +41,13 @@ export class EmployeeEarningRepository extends BaseRepository implements IEmploy
         return created;
     }
 
-    public async update(id: string, data: { chatterId?: number; date?: Date; amount?: number; description?: string | null; }): Promise<EmployeeEarningModel | null> {
+    public async update(id: string, data: { chatterId?: number | null; date?: Date; amount?: number; description?: string | null; }): Promise<EmployeeEarningModel | null> {
         const existing = await this.findById(id);
         if (!existing) return null;
         await this.execute<ResultSetHeader>(
             "UPDATE employee_earnings SET chatter_id = ?, date = ?, amount = ?, description = ? WHERE id = ?",
             [
-                data.chatterId ?? existing.chatterId,
+                data.chatterId !== undefined ? data.chatterId : existing.chatterId,
                 data.date ?? existing.date,
                 data.amount ?? existing.amount,
                 data.description ?? existing.description,


### PR DESCRIPTION
## Summary
- record F2F pay-per-message transactions even when no chatter shift is found by saving them with a null chatter ID
- allow employee earning records to use nullable chatter IDs through repository and model updates

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: ESLint config missing)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ba9f3585108327b7e2cd8e8744d5a0