### PR TITLE
Add model ID to earnings and revenue endpoint

### DIFF
--- a/src/business/models/EmployeeEarningModel.ts
+++ b/src/business/models/EmployeeEarningModel.ts
@@ -2,6 +2,7 @@ export class EmployeeEarningModel {
     constructor(
         private _id: string,
         private _chatterId: number | null,
+        private _modelId: number | null,
         private _date: Date,           // business date
         private _amount: number,       // decimal(10,2)
         private _description: string | null,
@@ -12,6 +13,7 @@ export class EmployeeEarningModel {
         return {
             id: this.id,
             chatterId: this.chatterId,
+            modelId: this.modelId,
             date: this.date,             // keep Date; JSON will serialize to ISO
             amount: this.amount,
             description: this.description,
@@ -22,6 +24,7 @@ export class EmployeeEarningModel {
     // Getters
     get id(): string { return this._id; }
     get chatterId(): number | null { return this._chatterId; }
+    get modelId(): number | null { return this._modelId; }
     get date(): Date { return this._date; }
     get amount(): number { return this._amount; }
     get description(): string | null { return this._description; }
@@ -31,6 +34,7 @@ export class EmployeeEarningModel {
         return new EmployeeEarningModel(
             String(r.id),
             r.chatter_id != null ? Number(r.chatter_id) : null,
+            r.model_id != null ? Number(r.model_id) : null,
             new Date(r.date),
             Number(r.amount),
             r.description != null ? String(r.description) : null,

--- a/src/business/services/EmployeeEarningService.ts
+++ b/src/business/services/EmployeeEarningService.ts
@@ -35,7 +35,7 @@ export class EmployeeEarningService {
      * Creates a new employee earning record.
      * @param data Earning details.
      */
-    public async create(data: { chatterId: number; date: Date; amount: number; description?: string | null; }): Promise<EmployeeEarningModel> {
+    public async create(data: { chatterId: number | null; modelId: number | null; date: Date; amount: number; description?: string | null; }): Promise<EmployeeEarningModel> {
         return this.earningRepo.create(data);
     }
 
@@ -44,7 +44,7 @@ export class EmployeeEarningService {
      * @param id Earning identifier.
      * @param data Partial earning data.
      */
-    public async update(id: string, data: { chatterId?: number; date?: Date; amount?: number; description?: string | null; }): Promise<EmployeeEarningModel | null> {
+    public async update(id: string, data: { chatterId?: number | null; modelId?: number | null; date?: Date; amount?: number; description?: string | null; }): Promise<EmployeeEarningModel | null> {
         return this.earningRepo.update(id, data);
     }
 

--- a/src/business/services/F2FTransactionSyncService.ts
+++ b/src/business/services/F2FTransactionSyncService.ts
@@ -111,6 +111,7 @@ export class F2FTransactionSyncService {
             await this.earningRepo.create({
                 id,
                 chatterId: shift ? shift.chatterId : null,
+                modelId,
                 date: shift ? shift.date : ts,
                 amount: revenue,
                 description: `F2F: -User: ${detail.user} - Time: ${timeStr}`,

--- a/src/business/services/F2FUnlockSyncService.ts
+++ b/src/business/services/F2FUnlockSyncService.ts
@@ -175,6 +175,7 @@ export class F2FUnlockSyncService {
                     console.log(`F2F: Logging earning for unlock in chat ${chat.id} at ${u.datetime} for $${u.price}`);
                     await this.earningRepo.create({
                         chatterId: chatter?.id || 0,
+                        modelId: model.id,
                         date: shift?.date || ts,
                         amount: u.price,
                         description: `unlock: ${creator} @ ${u.datetime.split("T")[0]}`,

--- a/src/business/services/RevenueService.ts
+++ b/src/business/services/RevenueService.ts
@@ -1,0 +1,16 @@
+import {inject, injectable} from "tsyringe";
+import {IEmployeeEarningRepository} from "../../data/interfaces/IEmployeeEarningRepository";
+import {F2FTransactionSyncService} from "./F2FTransactionSyncService";
+
+@injectable()
+export class RevenueService {
+    constructor(
+        @inject("IEmployeeEarningRepository") private earningRepo: IEmployeeEarningRepository,
+        private txnSync: F2FTransactionSyncService,
+    ) {}
+
+    public async getEarnings(): Promise<{ id: string; amount: number; modelId: number | null; modelCommissionRate: number | null; chatterId: number | null; chatterCommissionRate: number | null; }[]> {
+        await this.txnSync.syncRecentPayPerMessage().catch(console.error);
+        return this.earningRepo.findAllWithCommissionRates();
+    }
+}

--- a/src/container/index.ts
+++ b/src/container/index.ts
@@ -19,6 +19,7 @@ import {F2FTransactionSyncService} from "../business/services/F2FTransactionSync
 import {ModelService} from "../business/services/ModelService";
 import {IModelRepository} from "../data/interfaces/IModelRepository";
 import {ModelRepository} from "../data/repositories/ModelRepository";
+import {RevenueService} from "../business/services/RevenueService";
 
 container.register("UserService", { useClass: UserService });
 
@@ -51,3 +52,4 @@ container.register<IModelRepository>("IModelRepository", {
 });
 container.register("F2FUnlockSyncService", { useClass: F2FUnlockSyncService });
 container.registerSingleton(F2FTransactionSyncService);
+container.register("RevenueService", { useClass: RevenueService });

--- a/src/controllers/RevenueController.ts
+++ b/src/controllers/RevenueController.ts
@@ -1,0 +1,19 @@
+import {Request, Response} from "express";
+import {container} from "tsyringe";
+import {RevenueService} from "../business/services/RevenueService";
+
+export class RevenueController {
+    private get service(): RevenueService {
+        return container.resolve(RevenueService);
+    }
+
+    public async getEarnings(_req: Request, res: Response): Promise<void> {
+        try {
+            const earnings = await this.service.getEarnings();
+            res.json(earnings);
+        } catch (err) {
+            console.error(err);
+            res.status(500).send("Error fetching revenue earnings");
+        }
+    }
+}

--- a/src/data/interfaces/IEmployeeEarningRepository.ts
+++ b/src/data/interfaces/IEmployeeEarningRepository.ts
@@ -6,16 +6,27 @@ export interface IEmployeeEarningRepository {
     create(data: {
         id?: string;
         chatterId: number | null;
+        modelId: number | null;
         date: Date;
         amount: number;
         description?: string | null;
     }): Promise<EmployeeEarningModel>;
     update(id: string, data: {
         chatterId?: number | null;
+        modelId?: number | null;
         date?: Date;
         amount?: number;
         description?: string | null;
     }): Promise<EmployeeEarningModel | null>;
     delete(id: string): Promise<void>;
     getLastId(): Promise<string | null>;
+
+    findAllWithCommissionRates(): Promise<{
+        id: string;
+        amount: number;
+        modelId: number | null;
+        modelCommissionRate: number | null;
+        chatterId: number | null;
+        chatterCommissionRate: number | null;
+    }[]>;
 }

--- a/src/data/repositories/EmployeeEarningRepository.ts
+++ b/src/data/repositories/EmployeeEarningRepository.ts
@@ -6,7 +6,7 @@ import {ResultSetHeader, RowDataPacket} from "mysql2";
 export class EmployeeEarningRepository extends BaseRepository implements IEmployeeEarningRepository {
     public async findAll(): Promise<EmployeeEarningModel[]> {
         const rows = await this.execute<RowDataPacket[]>(
-            "SELECT id, chatter_id, date, amount, description, created_at FROM employee_earnings ORDER BY date DESC",
+            "SELECT id, chatter_id, model_id, date, amount, description, created_at FROM employee_earnings ORDER BY date DESC",
             []
         );
         return rows.map(EmployeeEarningModel.fromRow);
@@ -14,17 +14,17 @@ export class EmployeeEarningRepository extends BaseRepository implements IEmploy
 
     public async findById(id: string): Promise<EmployeeEarningModel | null> {
         const rows = await this.execute<RowDataPacket[]>(
-            "SELECT id, chatter_id, date, amount, description, created_at FROM employee_earnings WHERE id = ?",
+            "SELECT id, chatter_id, model_id, date, amount, description, created_at FROM employee_earnings WHERE id = ?",
             [id]
         );
         return rows.length ? EmployeeEarningModel.fromRow(rows[0]) : null;
     }
 
-    public async create(data: { id?: string; chatterId: number | null; date: Date; amount: number; description?: string | null; }): Promise<EmployeeEarningModel> {
+    public async create(data: { id?: string; chatterId: number | null; modelId: number | null; date: Date; amount: number; description?: string | null; }): Promise<EmployeeEarningModel> {
         if (data.id) {
             await this.execute<ResultSetHeader>(
-                "INSERT INTO employee_earnings (id, chatter_id, date, amount, description) VALUES (?, ?, ?, ?, ?)",
-                [data.id, data.chatterId ?? null, data.date, data.amount, data.description ?? null]
+                "INSERT INTO employee_earnings (id, chatter_id, model_id, date, amount, description) VALUES (?, ?, ?, ?, ?, ?)",
+                [data.id, data.chatterId ?? null, data.modelId ?? null, data.date, data.amount, data.description ?? null]
             );
             const created = await this.findById(data.id);
             if (!created) throw new Error("Failed to fetch created earning");
@@ -32,8 +32,8 @@ export class EmployeeEarningRepository extends BaseRepository implements IEmploy
         }
 
         const result = await this.execute<ResultSetHeader>(
-            "INSERT INTO employee_earnings (chatter_id, date, amount, description) VALUES (?, ?, ?, ?)",
-            [data.chatterId ?? null, data.date, data.amount, data.description ?? null]
+            "INSERT INTO employee_earnings (chatter_id, model_id, date, amount, description) VALUES (?, ?, ?, ?, ?)",
+            [data.chatterId ?? null, data.modelId ?? null, data.date, data.amount, data.description ?? null]
         );
         const insertedId = String(result.insertId);
         const created = await this.findById(insertedId);
@@ -41,13 +41,14 @@ export class EmployeeEarningRepository extends BaseRepository implements IEmploy
         return created;
     }
 
-    public async update(id: string, data: { chatterId?: number | null; date?: Date; amount?: number; description?: string | null; }): Promise<EmployeeEarningModel | null> {
+    public async update(id: string, data: { chatterId?: number | null; modelId?: number | null; date?: Date; amount?: number; description?: string | null; }): Promise<EmployeeEarningModel | null> {
         const existing = await this.findById(id);
         if (!existing) return null;
         await this.execute<ResultSetHeader>(
-            "UPDATE employee_earnings SET chatter_id = ?, date = ?, amount = ?, description = ? WHERE id = ?",
+            "UPDATE employee_earnings SET chatter_id = ?, model_id = ?, date = ?, amount = ?, description = ? WHERE id = ?",
             [
                 data.chatterId !== undefined ? data.chatterId : existing.chatterId,
+                data.modelId !== undefined ? data.modelId : existing.modelId,
                 data.date ?? existing.date,
                 data.amount ?? existing.amount,
                 data.description ?? existing.description,
@@ -70,5 +71,24 @@ export class EmployeeEarningRepository extends BaseRepository implements IEmploy
             []
         );
         return rows.length ? String(rows[0].id) : null;
+    }
+
+    public async findAllWithCommissionRates(): Promise<{ id: string; amount: number; modelId: number | null; modelCommissionRate: number | null; chatterId: number | null; chatterCommissionRate: number | null; }[]> {
+        const rows = await this.execute<RowDataPacket[]>(
+            `SELECT ee.id, ee.amount, ee.model_id, m.commission_rate AS model_commission_rate, ee.chatter_id, c.commission_rate AS chatter_commission_rate
+             FROM employee_earnings ee
+             LEFT JOIN models m ON ee.model_id = m.id
+             LEFT JOIN chatters c ON ee.chatter_id = c.id
+             ORDER BY ee.date DESC`,
+            []
+        );
+        return rows.map(r => ({
+            id: String(r.id),
+            amount: Number(r.amount),
+            modelId: r.model_id != null ? Number(r.model_id) : null,
+            modelCommissionRate: r.model_commission_rate != null ? Number(r.model_commission_rate) : null,
+            chatterId: r.chatter_id != null ? Number(r.chatter_id) : null,
+            chatterCommissionRate: r.chatter_commission_rate != null ? Number(r.chatter_commission_rate) : null,
+        }));
     }
 }

--- a/src/routes/RevenueRoute.ts
+++ b/src/routes/RevenueRoute.ts
@@ -1,0 +1,10 @@
+import {Router} from "express";
+import {authenticateToken} from "../middleware/auth";
+import {RevenueController} from "../controllers/RevenueController";
+
+const router = Router();
+const controller = new RevenueController();
+
+router.get("/earnings", authenticateToken, controller.getEarnings.bind(controller));
+
+export default router;

--- a/src/server.ts
+++ b/src/server.ts
@@ -6,6 +6,7 @@ import chatterRoute from "./routes/ChatterRoute";
 import employeeEarningRoute from "./routes/EmployeeEarningRoute";
 import shiftRoute from "./routes/ShiftRoute";
 import modelRoute from "./routes/ModelRoute";
+import revenueRoute from "./routes/RevenueRoute";
 
 import cors from "cors";
 
@@ -53,6 +54,7 @@ app.use("/api/chatters", chatterRoute);
 app.use("/api/employee-earnings", employeeEarningRoute);
 app.use("/api/shifts", shiftRoute);
 app.use("/api/models", modelRoute);
+app.use("/api/revenue", revenueRoute);
 
 // Health
 app.get("/api/health", (_req, res) => res.json({ ok: true }));


### PR DESCRIPTION
## Summary
- capture model IDs when logging F2F transactions
- expose revenue earnings with model and chatter commission rates via new endpoint

## Testing
- `npm test` (fails: sh: 1: jest: not found)
- `npm install jest --no-save` (fails: 403 Forbidden - GET https://registry.npmjs.org/jest)
- `npm run lint` (fails: ESLint couldn't find an eslint.config.(js|mjs|cjs) file)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bab5c3e1c883278f07d94ef06ceab8