### PR TITLE
feat: add endpoint for online chatters

### DIFF
--- a/src/business/services/ChatterService.ts
+++ b/src/business/services/ChatterService.ts
@@ -44,6 +44,10 @@ export class ChatterService {
         return this.chatterRepo.update(id, data);
     }
 
+    public async getOnline(): Promise<ChatterModel[]> {
+        return this.chatterRepo.findOnline();
+    }
+
     /**
      * Deletes a chatter by ID.
      * @param id Chatter identifier.

--- a/src/controllers/ChatterController.ts
+++ b/src/controllers/ChatterController.ts
@@ -25,6 +25,16 @@ export class ChatterController {
         }
     }
 
+    public async getOnline(_req: Request, res: Response): Promise<void> {
+        try {
+            const chatters = await this.service.getOnline();
+            res.json(chatters.map(c => c.toJSON()));
+        } catch (err) {
+            console.error(err);
+            res.status(500).send("Error fetching online chatters");
+        }
+    }
+
     /**
      * Retrieves a chatter by ID.
      * @param req Express request object.

--- a/src/data/interfaces/IChatterRepository.ts
+++ b/src/data/interfaces/IChatterRepository.ts
@@ -5,6 +5,7 @@ export interface IChatterRepository {
     findAll(): Promise<ChatterModel[]>;
     findById(id: number): Promise<ChatterModel | null>;
     findByEmail(email: string): Promise<ChatterModel | null>;
+    findOnline(): Promise<ChatterModel[]>;
     create(data: {
         userId: number;
         email: string;

--- a/src/data/repositories/ChatterRepository.ts
+++ b/src/data/repositories/ChatterRepository.ts
@@ -29,6 +29,17 @@ export class ChatterRepository extends BaseRepository implements IChatterReposit
         return rows.length ? ChatterModel.fromRow(rows[0]) : null;
     }
 
+    public async findOnline(): Promise<ChatterModel[]> {
+        const rows = await this.execute<RowDataPacket[]>(
+            `SELECT DISTINCT c.id, c.email, c.currency, c.commission_rate, c.platform_fee, c.status, c.created_at
+               FROM chatters c
+               JOIN shifts s ON s.chatter_id = c.id
+               WHERE s.status = 'active'`,
+            []
+        );
+        return rows.map(ChatterModel.fromRow);
+    }
+
     public async create(data: {userId: number, email: string; currency: CurrencySymbol; commissionRate: number; platformFeeRate: number; status: ChatterStatus; }): Promise<ChatterModel> {
         const result = await this.execute<ResultSetHeader>(
             "INSERT INTO chatters (id, email, currency, commission_rate, platform_fee, status) VALUES (?, ?, ?, ?, ?, ?)",

--- a/src/routes/ChatterRoute.ts
+++ b/src/routes/ChatterRoute.ts
@@ -6,6 +6,7 @@ const router = Router();
 const controller = new ChatterController();
 
 router.get("/", authenticateToken, controller.getAll.bind(controller));
+router.get("/online", authenticateToken, controller.getOnline.bind(controller));
 router.get("/:id", authenticateToken, controller.getById.bind(controller));
 router.post("/", authenticateToken, controller.create.bind(controller));
 router.put("/:id", authenticateToken, controller.update.bind(controller));


### PR DESCRIPTION
## Summary
- add repository, service, controller & route to list chatters with active shifts

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm test` *(fails: jest not found)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bacb76356883279db5c50267a6e202