### PR TITLE
Handle multiple F2F transaction types and expose chatter-only earnings

### DIFF
--- a/src/business/models/EmployeeEarningModel.ts
+++ b/src/business/models/EmployeeEarningModel.ts
@@ -6,6 +6,7 @@ export class EmployeeEarningModel {
         private _date: Date,           // business date
         private _amount: number,       // decimal(10,2)
         private _description: string | null,
+        private _type: string | null,
         private _createdAt: Date,
     ) {}
 
@@ -17,6 +18,7 @@ export class EmployeeEarningModel {
             date: this.date,             // keep Date; JSON will serialize to ISO
             amount: this.amount,
             description: this.description,
+            type: this.type,
             createdAt: this.createdAt,
         };
     }
@@ -28,6 +30,7 @@ export class EmployeeEarningModel {
     get date(): Date { return this._date; }
     get amount(): number { return this._amount; }
     get description(): string | null { return this._description; }
+    get type(): string | null { return this._type; }
     get createdAt(): Date { return this._createdAt; }
 
     static fromRow(r: any): EmployeeEarningModel {
@@ -38,6 +41,7 @@ export class EmployeeEarningModel {
             new Date(r.date),
             Number(r.amount),
             r.description != null ? String(r.description) : null,
+            r.type != null ? String(r.type) : null,
             new Date(r.created_at),
         );
     }

--- a/src/business/services/EmployeeEarningService.ts
+++ b/src/business/services/EmployeeEarningService.ts
@@ -17,8 +17,8 @@ export class EmployeeEarningService {
      * Retrieves all employee earnings after syncing recent transactions.
      */
     public async getAll(): Promise<EmployeeEarningModel[]> {
-        console.log("Syncing recent pay per message transactions...");
-        await this.txnSync.syncRecentPayPerMessage().catch(console.error);
+        console.log("Syncing recent F2F transactions...");
+        await this.txnSync.syncRecentTransactions().catch(console.error);
         return this.earningRepo.findAll();
     }
 
@@ -27,15 +27,23 @@ export class EmployeeEarningService {
      * @param id Earning identifier.
      */
     public async getById(id: string): Promise<EmployeeEarningModel | null> {
-        await this.txnSync.syncRecentPayPerMessage().catch(console.error);
+        await this.txnSync.syncRecentTransactions().catch(console.error);
         return this.earningRepo.findById(id);
+    }
+
+    /**
+     * Retrieves earnings that have a chatter linked.
+     */
+    public async getAllWithChatter(): Promise<EmployeeEarningModel[]> {
+        await this.txnSync.syncRecentTransactions().catch(console.error);
+        return this.earningRepo.findAllWithChatter();
     }
 
     /**
      * Creates a new employee earning record.
      * @param data Earning details.
      */
-    public async create(data: { chatterId: number | null; modelId: number | null; date: Date; amount: number; description?: string | null; }): Promise<EmployeeEarningModel> {
+    public async create(data: { chatterId: number | null; modelId: number | null; date: Date; amount: number; description?: string | null; type?: string | null; }): Promise<EmployeeEarningModel> {
         return this.earningRepo.create(data);
     }
 
@@ -44,7 +52,7 @@ export class EmployeeEarningService {
      * @param id Earning identifier.
      * @param data Partial earning data.
      */
-    public async update(id: string, data: { chatterId?: number | null; modelId?: number | null; date?: Date; amount?: number; description?: string | null; }): Promise<EmployeeEarningModel | null> {
+    public async update(id: string, data: { chatterId?: number | null; modelId?: number | null; date?: Date; amount?: number; description?: string | null; type?: string | null; }): Promise<EmployeeEarningModel | null> {
         return this.earningRepo.update(id, data);
     }
 

--- a/src/business/services/F2FTransactionSyncService.ts
+++ b/src/business/services/F2FTransactionSyncService.ts
@@ -11,7 +11,7 @@ const COOKIES = process.env.F2F_COOKIES || "";
 const sleep = (ms: number) => new Promise(res => setTimeout(res, ms));
 
 /**
- * Service that syncs recent pay-per-message transactions from F2F.
+ * Service that syncs recent transactions from F2F.
  */
 @injectable()
 export class F2FTransactionSyncService {
@@ -95,24 +95,23 @@ export class F2FTransactionSyncService {
     }
 
     /**
-     * Syncs recent pay-per-message transactions to earnings.
+     * Syncs recent transactions to earnings.
      */
-    public async syncRecentPayPerMessage(): Promise<void> {
+    public async syncRecentTransactions(): Promise<void> {
         if (!COOKIES) {
             throw new Error("F2F_COOKIES env var required");
         }
 
         this.lastSeenUuid = await this.earningRepo.getLastId();
         const list = await this.fetchTransactions();
-        const payPerMessages = list.filter((t: any) => t.object_type === "paypermessage");
-        console.log(`Fetched ${list.length} transactions, ${payPerMessages.length} are paypermessage`);
-        if (!payPerMessages.length) return;
+        console.log(`Fetched ${list.length} transactions`);
+        if (!list.length) return;
 
-        let newTxns = payPerMessages;
+        let newTxns = list;
         if (this.lastSeenUuid) {
             console.log(`Last seen txn uuid: ${this.lastSeenUuid}`);
-            const idx = payPerMessages.findIndex((t: any) => t.uuid === this.lastSeenUuid);
-            if (idx >= 0) newTxns = payPerMessages.slice(0, idx);
+            const idx = list.findIndex((t: any) => t.uuid === this.lastSeenUuid);
+            if (idx >= 0) newTxns = list.slice(0, idx);
         }
         if (!newTxns.length) return;
 
@@ -132,18 +131,25 @@ export class F2FTransactionSyncService {
             if (!modelId) continue;
             const ts = new Date(detail.created);
             const timeStr = ts.toTimeString().split(" ")[0];
-            const shift = await this.shiftRepo.findShiftForModelAt(modelId, ts);
-            console.log(`  -> model ${creator} id ${modelId}, found shift: ${shift ? shift.id + ' models:' + shift.modelIds.join(',') : 'NO SHIFT'}`);
+            let chatterId: number | null = null;
+            let date = ts;
+            if (txn.object_type === "paypermessage" || txn.object_type === "tip") {
+                const shift = await this.shiftRepo.findShiftForModelAt(modelId, ts);
+                console.log(`  -> model ${creator} id ${modelId}, found shift: ${shift ? shift.id + ' models:' + shift.modelIds.join(',') : 'NO SHIFT'}`);
+                chatterId = shift ? shift.chatterId : null;
+                date = shift ? shift.date : ts;
+            }
             const id = txn.uuid;
             const existing = await this.earningRepo.findById(id);
             if (existing) continue;
             await this.earningRepo.create({
                 id,
-                chatterId: shift ? shift.chatterId : null,
+                chatterId,
                 modelId,
-                date: shift ? shift.date : ts,
+                date,
                 amount: revenue,
                 description: `F2F: -User: ${detail.user} - Time: ${timeStr}`,
+                type: txn.object_type,
             });
         }
     }

--- a/src/business/services/RevenueService.ts
+++ b/src/business/services/RevenueService.ts
@@ -10,7 +10,7 @@ export class RevenueService {
     ) {}
 
     public async getEarnings(): Promise<{ id: string; amount: number; modelId: number | null; modelCommissionRate: number | null; chatterId: number | null; chatterCommissionRate: number | null; }[]> {
-        await this.txnSync.syncRecentPayPerMessage().catch(console.error);
+        await this.txnSync.syncRecentTransactions().catch(console.error);
         return this.earningRepo.findAllWithCommissionRates();
     }
 }

--- a/src/controllers/EmployeeEarningController.ts
+++ b/src/controllers/EmployeeEarningController.ts
@@ -26,6 +26,21 @@ export class EmployeeEarningController {
     }
 
     /**
+     * Retrieves earnings that are linked to a chatter.
+     * @param _req Express request object.
+     * @param res Express response object.
+     */
+    public async getAllWithChatter(_req: Request, res: Response): Promise<void> {
+        try {
+            const earnings = await this.service.getAllWithChatter();
+            res.json(earnings.map(e => e.toJSON()));
+        } catch (err) {
+            console.error(err);
+            res.status(500).send("Error fetching earnings with chatter");
+        }
+    }
+
+    /**
      * Retrieves an earning by ID.
      * @param req Express request object.
      * @param res Express response object.

--- a/src/data/interfaces/IEmployeeEarningRepository.ts
+++ b/src/data/interfaces/IEmployeeEarningRepository.ts
@@ -10,6 +10,7 @@ export interface IEmployeeEarningRepository {
         date: Date;
         amount: number;
         description?: string | null;
+        type?: string | null;
     }): Promise<EmployeeEarningModel>;
     update(id: string, data: {
         chatterId?: number | null;
@@ -17,9 +18,12 @@ export interface IEmployeeEarningRepository {
         date?: Date;
         amount?: number;
         description?: string | null;
+        type?: string | null;
     }): Promise<EmployeeEarningModel | null>;
     delete(id: string): Promise<void>;
     getLastId(): Promise<string | null>;
+
+    findAllWithChatter(): Promise<EmployeeEarningModel[]>;
 
     findAllWithCommissionRates(): Promise<{
         id: string;

--- a/src/data/repositories/EmployeeEarningRepository.ts
+++ b/src/data/repositories/EmployeeEarningRepository.ts
@@ -6,7 +6,7 @@ import {ResultSetHeader, RowDataPacket} from "mysql2";
 export class EmployeeEarningRepository extends BaseRepository implements IEmployeeEarningRepository {
     public async findAll(): Promise<EmployeeEarningModel[]> {
         const rows = await this.execute<RowDataPacket[]>(
-            "SELECT id, chatter_id, model_id, date, amount, description, created_at FROM employee_earnings ORDER BY date DESC",
+            "SELECT id, chatter_id, model_id, date, amount, description, type, created_at FROM employee_earnings ORDER BY date DESC",
             []
         );
         return rows.map(EmployeeEarningModel.fromRow);
@@ -14,17 +14,17 @@ export class EmployeeEarningRepository extends BaseRepository implements IEmploy
 
     public async findById(id: string): Promise<EmployeeEarningModel | null> {
         const rows = await this.execute<RowDataPacket[]>(
-            "SELECT id, chatter_id, model_id, date, amount, description, created_at FROM employee_earnings WHERE id = ?",
+            "SELECT id, chatter_id, model_id, date, amount, description, type, created_at FROM employee_earnings WHERE id = ?",
             [id]
         );
         return rows.length ? EmployeeEarningModel.fromRow(rows[0]) : null;
     }
 
-    public async create(data: { id?: string; chatterId: number | null; modelId: number | null; date: Date; amount: number; description?: string | null; }): Promise<EmployeeEarningModel> {
+    public async create(data: { id?: string; chatterId: number | null; modelId: number | null; date: Date; amount: number; description?: string | null; type?: string | null; }): Promise<EmployeeEarningModel> {
         if (data.id) {
             await this.execute<ResultSetHeader>(
-                "INSERT INTO employee_earnings (id, chatter_id, model_id, date, amount, description) VALUES (?, ?, ?, ?, ?, ?)",
-                [data.id, data.chatterId ?? null, data.modelId ?? null, data.date, data.amount, data.description ?? null]
+                "INSERT INTO employee_earnings (id, chatter_id, model_id, date, amount, description, type) VALUES (?, ?, ?, ?, ?, ?, ?)",
+                [data.id, data.chatterId ?? null, data.modelId ?? null, data.date, data.amount, data.description ?? null, data.type ?? null]
             );
             const created = await this.findById(data.id);
             if (!created) throw new Error("Failed to fetch created earning");
@@ -32,8 +32,8 @@ export class EmployeeEarningRepository extends BaseRepository implements IEmploy
         }
 
         const result = await this.execute<ResultSetHeader>(
-            "INSERT INTO employee_earnings (chatter_id, model_id, date, amount, description) VALUES (?, ?, ?, ?, ?)",
-            [data.chatterId ?? null, data.modelId ?? null, data.date, data.amount, data.description ?? null]
+            "INSERT INTO employee_earnings (chatter_id, model_id, date, amount, description, type) VALUES (?, ?, ?, ?, ?, ?)",
+            [data.chatterId ?? null, data.modelId ?? null, data.date, data.amount, data.description ?? null, data.type ?? null]
         );
         const insertedId = String(result.insertId);
         const created = await this.findById(insertedId);
@@ -41,17 +41,18 @@ export class EmployeeEarningRepository extends BaseRepository implements IEmploy
         return created;
     }
 
-    public async update(id: string, data: { chatterId?: number | null; modelId?: number | null; date?: Date; amount?: number; description?: string | null; }): Promise<EmployeeEarningModel | null> {
+    public async update(id: string, data: { chatterId?: number | null; modelId?: number | null; date?: Date; amount?: number; description?: string | null; type?: string | null; }): Promise<EmployeeEarningModel | null> {
         const existing = await this.findById(id);
         if (!existing) return null;
         await this.execute<ResultSetHeader>(
-            "UPDATE employee_earnings SET chatter_id = ?, model_id = ?, date = ?, amount = ?, description = ? WHERE id = ?",
+            "UPDATE employee_earnings SET chatter_id = ?, model_id = ?, date = ?, amount = ?, description = ?, type = ? WHERE id = ?",
             [
                 data.chatterId !== undefined ? data.chatterId : existing.chatterId,
                 data.modelId !== undefined ? data.modelId : existing.modelId,
                 data.date ?? existing.date,
                 data.amount ?? existing.amount,
                 data.description ?? existing.description,
+                data.type ?? existing.type,
                 id
             ]
         );
@@ -71,6 +72,14 @@ export class EmployeeEarningRepository extends BaseRepository implements IEmploy
             []
         );
         return rows.length ? String(rows[0].id) : null;
+    }
+
+    public async findAllWithChatter(): Promise<EmployeeEarningModel[]> {
+        const rows = await this.execute<RowDataPacket[]>(
+            "SELECT id, chatter_id, model_id, date, amount, description, type, created_at FROM employee_earnings WHERE chatter_id IS NOT NULL ORDER BY date DESC",
+            []
+        );
+        return rows.map(EmployeeEarningModel.fromRow);
     }
 
     public async findAllWithCommissionRates(): Promise<{ id: string; amount: number; modelId: number | null; modelCommissionRate: number | null; chatterId: number | null; chatterCommissionRate: number | null; }[]> {

--- a/src/routes/EmployeeEarningRoute.ts
+++ b/src/routes/EmployeeEarningRoute.ts
@@ -8,6 +8,7 @@ const controller = new EmployeeEarningController();
 router.use(authenticateToken);
 
 router.get("/", controller.getAll.bind(controller));
+router.get("/chatter", controller.getAllWithChatter.bind(controller));
 router.get("/:id", controller.getById.bind(controller));
 router.post("/", controller.create.bind(controller));
 router.put("/:id", controller.update.bind(controller));

--- a/src/tasks/syncTransactionEarnings.ts
+++ b/src/tasks/syncTransactionEarnings.ts
@@ -5,7 +5,7 @@ import {F2FTransactionSyncService} from '../business/services/F2FTransactionSync
 
 async function runOnce() {
   const svc = container.resolve(F2FTransactionSyncService);
-  await svc.syncRecentPayPerMessage();
+  await svc.syncRecentTransactions();
 }
 
 runOnce().catch(err => {


### PR DESCRIPTION
## Summary
- Record F2F transaction type on employee earnings and link chatters only for pay-per-message and tips
- Expand F2F transaction sync to process all transaction types
- Add route to fetch earnings associated with a chatter

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: ESLint config missing)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68bae9e7934c832783132b8823d70e48