### PR TITLE
feat: add filters for employee earnings

### DIFF
--- a/src/business/services/EmployeeEarningService.ts
+++ b/src/business/services/EmployeeEarningService.ts
@@ -17,10 +17,15 @@ export class EmployeeEarningService {
     /**
      * Retrieves all employee earnings after syncing recent transactions.
      */
-    public async getAll(): Promise<EmployeeEarningModel[]> {
+    public async getAll(params: {
+        limit?: number;
+        offset?: number;
+        chatterId?: number;
+        type?: string;
+    } = {}): Promise<EmployeeEarningModel[]> {
         console.log("Syncing recent F2F transactions...");
         await this.txnSync.syncRecentTransactions().catch(console.error);
-        return this.earningRepo.findAll();
+        return this.earningRepo.findAll(params);
     }
 
     /**

--- a/src/business/services/F2FTransactionSyncService.ts
+++ b/src/business/services/F2FTransactionSyncService.ts
@@ -122,8 +122,11 @@ export class F2FTransactionSyncService {
         // process oldest first
         for (const txn of newTxns.reverse()) {
             if (txn.uuid === this.lastSeenUuid) break;
-            const detail = await this.fetchTransactionDetail(txn.uuid);
-            console.log(`Processing txn ${txn.uuid} for user ${detail.user}, revenue ${detail.revenue}`);
+            const id = txn.uuid;
+            const existing = await this.earningRepo.findById(id);
+            if (existing) continue;
+            const detail = await this.fetchTransactionDetail(id);
+            console.log(`Processing txn ${id} for user ${detail.user}, revenue ${detail.revenue}`);
             const revenue = Number(detail.revenue || 0);
             const creator = detail.creator || txn.creator;
             const model = modelMap.get(creator);
@@ -139,9 +142,6 @@ export class F2FTransactionSyncService {
                 chatterId = shift ? shift.chatterId : null;
                 date = shift ? shift.date : ts;
             }
-            const id = txn.uuid;
-            const existing = await this.earningRepo.findById(id);
-            if (existing) continue;
             const txnType = txn.object_type?.startsWith("subscriptionperiod")
                 ? "subscriptionperiod"
                 : txn.object_type;

--- a/src/controllers/EmployeeEarningController.ts
+++ b/src/controllers/EmployeeEarningController.ts
@@ -12,12 +12,16 @@ export class EmployeeEarningController {
 
     /**
      * Retrieves all employee earnings.
-     * @param _req Express request object.
+     * @param req Express request object.
      * @param res Express response object.
      */
-    public async getAll(_req: Request, res: Response): Promise<void> {
+    public async getAll(req: Request, res: Response): Promise<void> {
         try {
-            const earnings = await this.service.getAll();
+            const limit = req.query.limit ? Number(req.query.limit) : undefined;
+            const offset = req.query.offset ? Number(req.query.offset) : undefined;
+            const chatterId = req.query.chatterId ? Number(req.query.chatterId) : undefined;
+            const type = req.query.type ? String(req.query.type) : undefined;
+            const earnings = await this.service.getAll({limit, offset, chatterId, type});
             res.json(earnings.map(e => e.toJSON()));
         } catch (err) {
             console.error(err);

--- a/src/data/interfaces/IEmployeeEarningRepository.ts
+++ b/src/data/interfaces/IEmployeeEarningRepository.ts
@@ -1,7 +1,12 @@
 import {EmployeeEarningModel} from "../../business/models/EmployeeEarningModel";
 
 export interface IEmployeeEarningRepository {
-    findAll(): Promise<EmployeeEarningModel[]>;
+    findAll(params?: {
+        limit?: number;
+        offset?: number;
+        chatterId?: number;
+        type?: string;
+    }): Promise<EmployeeEarningModel[]>;
     findById(id: string): Promise<EmployeeEarningModel | null>;
     create(data: {
         id?: string;


### PR DESCRIPTION
## Summary
- allow querying employee earnings with limit, offset, chatterId and type
- skip fetching details for already-synced F2F transactions

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: ESLint couldn't find a config file)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bd3cafd0448327b51fe63d0e58c42c