### PR TITLE
Use Amsterdam time zone for server processes

### DIFF
--- a/src/config/timezone.ts
+++ b/src/config/timezone.ts
@@ -1,0 +1,3 @@
+// src/config/timezone.ts
+// Ensure all Date operations use the Europe/Amsterdam timezone
+process.env.TZ = "Europe/Amsterdam";

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,3 +1,4 @@
+import "./config/timezone";
 import "reflect-metadata";
 import "./container";
 import express from "express";

--- a/src/tasks/syncTransactionEarnings.ts
+++ b/src/tasks/syncTransactionEarnings.ts
@@ -1,3 +1,4 @@
+import '../config/timezone';
 import 'reflect-metadata';
 import '../container';
 import {container} from 'tsyringe';

--- a/src/tasks/syncUnlockEarnings.ts
+++ b/src/tasks/syncUnlockEarnings.ts
@@ -1,3 +1,4 @@
+import '../config/timezone';
 import 'reflect-metadata';
 import '../container';
 import {container} from 'tsyringe';


### PR DESCRIPTION
## Summary
- ensure all Date instances run in Europe/Amsterdam by setting `process.env.TZ`
- load timezone setup in server and sync tasks to keep time consistent

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config file)*
- `npm test` *(fails: jest not found)*
- `npm run build` *(fails: TS18048: 'params.offset' is possibly 'undefined')*


------
https://chatgpt.com/codex/tasks/task_e_68bfc399bdc4832790266c6420eb1010