### PR TITLE
docs: add jsdoc support and project readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,25 @@
+# ILGD CRM Backend
+
+Express and TypeScript backend for the ILGD CRM application.
+
+## Scripts
+
+- `npm run dev` - start development server with hot reload
+- `npm run build` - compile TypeScript sources
+- `npm start` - run the compiled server
+- `npm test` - execute tests
+- `npm run lint` - lint the codebase
+- `npm run docs` - generate API documentation (requires `jsdoc`)
+
+## Getting Started
+
+1. Install dependencies:
+   ```bash
+   npm install
+   ```
+2. Start the development server:
+   ```bash
+   npm run dev
+   ```
+
+Generated documentation is output to the `docs/` folder.

--- a/jsdoc.json
+++ b/jsdoc.json
@@ -1,0 +1,10 @@
+{
+  "source": {
+    "include": ["src"],
+    "includePattern": "\\.ts$"
+  },
+  "opts": {
+    "destination": "docs",
+    "recurse": true
+  }
+}

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "lint": "eslint 'src/**/*.ts'",
     "test": "jest",
     "sync:earnings": "ts-node src/tasks/syncUnlockEarnings.ts",
-    "sync:transactions": "ts-node src/tasks/syncTransactionEarnings.ts"
+    "sync:transactions": "ts-node src/tasks/syncTransactionEarnings.ts",
+    "docs": "jsdoc -c jsdoc.json"
   },
   "dependencies": {
     "@vercel/node": "^5.3.15",
@@ -34,6 +35,7 @@
     "prettier": "^3.6.2",
     "ts-node": "^10.9.2",
     "ts-node-dev": "^2.0.0",
-    "typescript": "^5.9.2"
+    "typescript": "^5.9.2",
+    "jsdoc": "^4.0.2"
   }
 }

--- a/src/business/models/ChatterLeaderboardModel.ts
+++ b/src/business/models/ChatterLeaderboardModel.ts
@@ -1,3 +1,9 @@
+/**
+ * ChatterLeaderboardModel module.
+ */
+/**
+ * ChatterLeaderboardModel class.
+ */
 export class ChatterLeaderboardModel {
     constructor(
         private _chatterId: number,

--- a/src/business/models/ChatterModel.ts
+++ b/src/business/models/ChatterModel.ts
@@ -1,5 +1,11 @@
+/**
+ * ChatterModel module.
+ */
 import {ChatterStatus, CurrencySymbol} from "../../rename/types";
 
+/**
+ * ChatterModel class.
+ */
 export class ChatterModel {
     constructor(
         private _id: number,                 // FK to users.id

--- a/src/business/models/CommissionModel.ts
+++ b/src/business/models/CommissionModel.ts
@@ -1,5 +1,11 @@
+/**
+ * CommissionModel module.
+ */
 import { CommissionStatus } from "../../rename/types";
 
+/**
+ * CommissionModel class.
+ */
 export class CommissionModel {
     constructor(
         private _id: number,

--- a/src/business/models/EmployeeEarningModel.ts
+++ b/src/business/models/EmployeeEarningModel.ts
@@ -1,4 +1,10 @@
+/**
+ * EmployeeEarningModel module.
+ */
 
+/**
+ * EmployeeEarningModel class.
+ */
 export class EmployeeEarningModel {
     constructor(
         private _id: string,

--- a/src/business/models/ModelModel.ts
+++ b/src/business/models/ModelModel.ts
@@ -1,4 +1,10 @@
+/**
+ * ModelModel module.
+ */
 
+/**
+ * ModelModel class.
+ */
 export class ModelModel {
     constructor(
         private _id: number,

--- a/src/business/models/RevenueModel.ts
+++ b/src/business/models/RevenueModel.ts
@@ -1,3 +1,9 @@
+/**
+ * RevenueModel module.
+ */
+/**
+ * RevenueModel class.
+ */
 export class RevenueModel {
     constructor(
         private _id: string,

--- a/src/business/models/ShiftModel.ts
+++ b/src/business/models/ShiftModel.ts
@@ -1,5 +1,11 @@
+/**
+ * ShiftModel module.
+ */
 import {ShiftStatus} from "../../rename/types";
 
+/**
+ * ShiftModel class.
+ */
 export class ShiftModel {
     constructor(
         private _id: number,

--- a/src/business/models/UserModel.ts
+++ b/src/business/models/UserModel.ts
@@ -1,5 +1,11 @@
+/**
+ * UserModel module.
+ */
 import {Role} from "../../rename/types";
 
+/**
+ * UserModel class.
+ */
 export class UserModel {
     constructor(
         private _id: number,

--- a/src/business/services/ChatterService.ts
+++ b/src/business/services/ChatterService.ts
@@ -1,3 +1,6 @@
+/**
+ * ChatterService module.
+ */
 import {inject, injectable} from "tsyringe";
 import {IChatterRepository} from "../../data/interfaces/IChatterRepository";
 import {ChatterModel} from "../models/ChatterModel";
@@ -7,6 +10,9 @@ import {ChatterStatus, CurrencySymbol} from "../../rename/types";
  * Service providing operations for chatters.
  */
 @injectable()
+/**
+ * ChatterService class.
+ */
 export class ChatterService {
     constructor(
         @inject("IChatterRepository") private chatterRepo: IChatterRepository

--- a/src/business/services/CommissionService.ts
+++ b/src/business/services/CommissionService.ts
@@ -1,3 +1,6 @@
+/**
+ * CommissionService module.
+ */
 import { inject, injectable } from "tsyringe";
 import { ICommissionRepository } from "../../data/interfaces/ICommissionRepository";
 import { CommissionModel } from "../models/CommissionModel";
@@ -7,6 +10,9 @@ import { CommissionStatus } from "../../rename/types";
  * Service managing commissions for chatters.
  */
 @injectable()
+/**
+ * CommissionService class.
+ */
 export class CommissionService {
     constructor(
         @inject("ICommissionRepository") private commissionRepo: ICommissionRepository

--- a/src/business/services/EmployeeEarningService.ts
+++ b/src/business/services/EmployeeEarningService.ts
@@ -1,3 +1,6 @@
+/**
+ * EmployeeEarningService module.
+ */
 import {inject, injectable} from "tsyringe";
 import {IEmployeeEarningRepository} from "../../data/interfaces/IEmployeeEarningRepository";
 import {EmployeeEarningModel} from "../models/EmployeeEarningModel";
@@ -9,6 +12,9 @@ import {IShiftRepository} from "../../data/interfaces/IShiftRepository";
  * Service for managing employee earnings and syncing transactions.
  */
 @injectable()
+/**
+ * EmployeeEarningService class.
+ */
 export class EmployeeEarningService {
     constructor(
         @inject("IEmployeeEarningRepository") private earningRepo: IEmployeeEarningRepository,

--- a/src/business/services/F2FTransactionSyncService.ts
+++ b/src/business/services/F2FTransactionSyncService.ts
@@ -1,3 +1,6 @@
+/**
+ * F2FTransactionSyncService module.
+ */
 import {inject, injectable} from "tsyringe";
 import {IShiftRepository} from "../../data/interfaces/IShiftRepository";
 import {IEmployeeEarningRepository} from "../../data/interfaces/IEmployeeEarningRepository";
@@ -14,6 +17,9 @@ const sleep = (ms: number) => new Promise(res => setTimeout(res, ms));
  * Service that syncs recent transactions from F2F.
  */
 @injectable()
+/**
+ * F2FTransactionSyncService class.
+ */
 export class F2FTransactionSyncService {
     private lastSeenUuid: string | null = null;
 

--- a/src/business/services/F2FUnlockSyncService.ts
+++ b/src/business/services/F2FUnlockSyncService.ts
@@ -1,3 +1,6 @@
+/**
+ * F2FUnlockSyncService module.
+ */
 import {inject, injectable} from "tsyringe";
 import {IChatterRepository} from "../../data/interfaces/IChatterRepository";
 import {IShiftRepository} from "../../data/interfaces/IShiftRepository";
@@ -15,6 +18,9 @@ const sleep = (ms: number) => new Promise(res => setTimeout(res, ms));
  * Service that synchronizes unlock earnings from the F2F platform.
  */
 @injectable()
+/**
+ * F2FUnlockSyncService class.
+ */
 export class F2FUnlockSyncService {
     constructor(
         @inject("IChatterRepository") private chatterRepo: IChatterRepository,

--- a/src/business/services/ModelService.ts
+++ b/src/business/services/ModelService.ts
@@ -1,3 +1,6 @@
+/**
+ * ModelService module.
+ */
 import {inject, injectable} from "tsyringe";
 import {IModelRepository} from "../../data/interfaces/IModelRepository";
 import {ModelModel} from "../models/ModelModel";
@@ -6,6 +9,9 @@ import {ModelModel} from "../models/ModelModel";
  * Service providing CRUD operations for models.
  */
 @injectable()
+/**
+ * ModelService class.
+ */
 export class ModelService {
     constructor(
         @inject("IModelRepository") private modelRepo: IModelRepository

--- a/src/business/services/RevenueService.ts
+++ b/src/business/services/RevenueService.ts
@@ -1,9 +1,15 @@
+/**
+ * RevenueService module.
+ */
 import {inject, injectable} from "tsyringe";
 import {IEmployeeEarningRepository} from "../../data/interfaces/IEmployeeEarningRepository";
 import {F2FTransactionSyncService} from "./F2FTransactionSyncService";
 import {RevenueModel} from "../models/RevenueModel";
 
 @injectable()
+/**
+ * RevenueService class.
+ */
 export class RevenueService {
     constructor(
         @inject("IEmployeeEarningRepository") private earningRepo: IEmployeeEarningRepository,

--- a/src/business/services/ShiftService.ts
+++ b/src/business/services/ShiftService.ts
@@ -1,3 +1,6 @@
+/**
+ * ShiftService module.
+ */
 import {inject, injectable} from "tsyringe";
 import {IShiftRepository} from "../../data/interfaces/IShiftRepository";
 import {ShiftModel} from "../models/ShiftModel";
@@ -7,6 +10,9 @@ import {ShiftStatus} from "../../rename/types";
  * Service responsible for shift management.
  */
 @injectable()
+/**
+ * ShiftService class.
+ */
 export class ShiftService {
     constructor(
         @inject("IShiftRepository") private shiftRepo: IShiftRepository

--- a/src/business/services/UserService.ts
+++ b/src/business/services/UserService.ts
@@ -1,3 +1,6 @@
+/**
+ * UserService module.
+ */
 import {inject, injectable} from "tsyringe";
 import {IUserRepository} from "../../data/interfaces/IUserRepository";
 import bcrypt from "bcrypt";
@@ -9,6 +12,9 @@ import {Role} from "../../rename/types";
  * Service responsible for user management and authentication.
  */
 @injectable()
+/**
+ * UserService class.
+ */
 export class UserService {
     constructor(
         @inject("IUserRepository") private userRepo: IUserRepository

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -1,3 +1,6 @@
+/**
+ * config module.
+ */
 // src/config/config.ts
 
 import dotenv from "dotenv";

--- a/src/config/database.ts
+++ b/src/config/database.ts
@@ -1,3 +1,6 @@
+/**
+ * database module.
+ */
 import mysql from 'mysql2/promise';
 import dotenv from 'dotenv';
 

--- a/src/config/timezone.ts
+++ b/src/config/timezone.ts
@@ -1,3 +1,6 @@
+/**
+ * timezone module.
+ */
 // src/config/timezone.ts
 // Ensure all Date operations use the Europe/Amsterdam timezone
 process.env.TZ = "Europe/Amsterdam";

--- a/src/container/index.ts
+++ b/src/container/index.ts
@@ -1,3 +1,6 @@
+/**
+ * index module.
+ */
 import {container} from "tsyringe";
 import {UserService} from "../business/services/UserService";
 import {IUserRepository} from "../data/interfaces/IUserRepository";

--- a/src/controllers/ChatterController.ts
+++ b/src/controllers/ChatterController.ts
@@ -1,9 +1,15 @@
+/**
+ * ChatterController module.
+ */
 import {Request, Response} from "express";
 import {container} from "tsyringe";
 import {ChatterService} from "../business/services/ChatterService";
 
 /**
  * Controller responsible for managing chatters.
+ */
+/**
+ * ChatterController class.
  */
 export class ChatterController {
     private get service(): ChatterService {

--- a/src/controllers/CommissionController.ts
+++ b/src/controllers/CommissionController.ts
@@ -1,9 +1,15 @@
+/**
+ * CommissionController module.
+ */
 import { Request, Response } from "express";
 import { container } from "tsyringe";
 import { CommissionService } from "../business/services/CommissionService";
 
 /**
  * Controller for commission CRUD operations.
+ */
+/**
+ * CommissionController class.
  */
 export class CommissionController {
     private get service(): CommissionService {

--- a/src/controllers/EmployeeEarningController.ts
+++ b/src/controllers/EmployeeEarningController.ts
@@ -1,9 +1,15 @@
+/**
+ * EmployeeEarningController module.
+ */
 import {Request, Response} from "express";
 import {container} from "tsyringe";
 import {EmployeeEarningService} from "../business/services/EmployeeEarningService";
 
 /**
  * Controller managing employee earnings.
+ */
+/**
+ * EmployeeEarningController class.
  */
 export class EmployeeEarningController {
     private get service(): EmployeeEarningService {

--- a/src/controllers/ModelController.ts
+++ b/src/controllers/ModelController.ts
@@ -1,9 +1,15 @@
+/**
+ * ModelController module.
+ */
 import {Request, Response} from "express";
 import {container} from "tsyringe";
 import {ModelService} from "../business/services/ModelService";
 
 /**
  * Controller for model-related operations.
+ */
+/**
+ * ModelController class.
  */
 export class ModelController {
     private get service(): ModelService {

--- a/src/controllers/RevenueController.ts
+++ b/src/controllers/RevenueController.ts
@@ -1,7 +1,13 @@
+/**
+ * RevenueController module.
+ */
 import {Request, Response} from "express";
 import {container} from "tsyringe";
 import {RevenueService} from "../business/services/RevenueService";
 
+/**
+ * RevenueController class.
+ */
 export class RevenueController {
     private get service(): RevenueService {
         return container.resolve(RevenueService);

--- a/src/controllers/ShiftController.ts
+++ b/src/controllers/ShiftController.ts
@@ -1,3 +1,6 @@
+/**
+ * ShiftController module.
+ */
 import {Request, Response} from "express";
 import {container} from "tsyringe";
 import {ShiftService} from "../business/services/ShiftService";
@@ -5,6 +8,9 @@ import {ShiftModel} from "../business/models/ShiftModel";
 
 /**
  * Controller handling shift scheduling and tracking.
+ */
+/**
+ * ShiftController class.
  */
 export class ShiftController {
     private get service(): ShiftService {

--- a/src/controllers/UserController.ts
+++ b/src/controllers/UserController.ts
@@ -1,3 +1,6 @@
+/**
+ * UserController module.
+ */
 import {UserService} from "../business/services/UserService";
 import {container} from "tsyringe";
 import { Request, Response } from "express";
@@ -5,6 +8,9 @@ import {UserModel} from "../business/models/UserModel";
 
 /**
  * Controller handling CRUD operations and authentication for users.
+ */
+/**
+ * UserController class.
  */
 export class UserController {
     private get service(): UserService {

--- a/src/data/interfaces/IChatterRepository.ts
+++ b/src/data/interfaces/IChatterRepository.ts
@@ -1,6 +1,12 @@
+/**
+ * IChatterRepository module.
+ */
 import {ChatterModel} from "../../business/models/ChatterModel";
 import {ChatterStatus, CurrencySymbol} from "../../rename/types";
 
+/**
+ * IChatterRepository interface.
+ */
 export interface IChatterRepository {
     findAll(): Promise<ChatterModel[]>;
     findById(id: number): Promise<ChatterModel | null>;

--- a/src/data/interfaces/ICommissionRepository.ts
+++ b/src/data/interfaces/ICommissionRepository.ts
@@ -1,6 +1,12 @@
+/**
+ * ICommissionRepository module.
+ */
 import { CommissionModel } from "../../business/models/CommissionModel";
 import { CommissionStatus } from "../../rename/types";
 
+/**
+ * ICommissionRepository interface.
+ */
 export interface ICommissionRepository {
     findAll(): Promise<CommissionModel[]>;
     findById(id: number): Promise<CommissionModel | null>;

--- a/src/data/interfaces/IEmployeeEarningRepository.ts
+++ b/src/data/interfaces/IEmployeeEarningRepository.ts
@@ -1,6 +1,12 @@
+/**
+ * IEmployeeEarningRepository module.
+ */
 import {EmployeeEarningModel} from "../../business/models/EmployeeEarningModel";
 import {RevenueModel} from "../../business/models/RevenueModel";
 
+/**
+ * IEmployeeEarningRepository interface.
+ */
 export interface IEmployeeEarningRepository {
     findAll(params?: {
         limit?: number;

--- a/src/data/interfaces/IModelRepository.ts
+++ b/src/data/interfaces/IModelRepository.ts
@@ -1,5 +1,11 @@
+/**
+ * IModelRepository module.
+ */
 import {ModelModel} from "../../business/models/ModelModel";
 
+/**
+ * IModelRepository interface.
+ */
 export interface IModelRepository {
     findAll(): Promise<ModelModel[]>;
     findById(id: number): Promise<ModelModel | null>;

--- a/src/data/interfaces/IShiftRepository.ts
+++ b/src/data/interfaces/IShiftRepository.ts
@@ -1,6 +1,12 @@
+/**
+ * IShiftRepository module.
+ */
 import {ShiftModel} from "../../business/models/ShiftModel";
 import {ShiftStatus} from "../../rename/types";
 
+/**
+ * IShiftRepository interface.
+ */
 export interface IShiftRepository {
     findAll(): Promise<ShiftModel[]>;
     findById(id: number): Promise<ShiftModel | null>;

--- a/src/data/interfaces/IUserRepository.ts
+++ b/src/data/interfaces/IUserRepository.ts
@@ -1,6 +1,12 @@
+/**
+ * IUserRepository module.
+ */
 import {UserModel} from "../../business/models/UserModel";
 import {Role} from "../../rename/types";
 
+/**
+ * IUserRepository interface.
+ */
 export interface IUserRepository {
     findAll(): Promise<UserModel[]>;
     findById(id: number): Promise<UserModel | null>;

--- a/src/data/repositories/BaseRepository.ts
+++ b/src/data/repositories/BaseRepository.ts
@@ -1,3 +1,6 @@
+/**
+ * BaseRepository module.
+ */
 // src/data/repositories/BaseRepository.ts
 import pool from "../../config/database";
 import { Pool } from "mysql2/promise";

--- a/src/data/repositories/ChatterRepository.ts
+++ b/src/data/repositories/ChatterRepository.ts
@@ -1,9 +1,15 @@
+/**
+ * ChatterRepository module.
+ */
 import {BaseRepository} from "./BaseRepository";
 import {IChatterRepository} from "../interfaces/IChatterRepository";
 import {ChatterModel} from "../../business/models/ChatterModel";
 import {ChatterStatus, CurrencySymbol} from "../../rename/types";
 import {ResultSetHeader, RowDataPacket} from "mysql2";
 
+/**
+ * ChatterRepository class.
+ */
 export class ChatterRepository extends BaseRepository implements IChatterRepository {
     public async findAll(): Promise<ChatterModel[]> {
         const rows = await this.execute<RowDataPacket[]>(

--- a/src/data/repositories/CommissionRepository.ts
+++ b/src/data/repositories/CommissionRepository.ts
@@ -1,9 +1,15 @@
+/**
+ * CommissionRepository module.
+ */
 import { BaseRepository } from "./BaseRepository";
 import { ICommissionRepository } from "../interfaces/ICommissionRepository";
 import { CommissionModel } from "../../business/models/CommissionModel";
 import { CommissionStatus } from "../../rename/types";
 import { ResultSetHeader, RowDataPacket } from "mysql2";
 
+/**
+ * CommissionRepository class.
+ */
 export class CommissionRepository extends BaseRepository implements ICommissionRepository {
     public async findAll(): Promise<CommissionModel[]> {
         const rows = await this.execute<RowDataPacket[]>(

--- a/src/data/repositories/EmployeeEarningRepository.ts
+++ b/src/data/repositories/EmployeeEarningRepository.ts
@@ -1,9 +1,15 @@
+/**
+ * EmployeeEarningRepository module.
+ */
 import {BaseRepository} from "./BaseRepository";
 import {IEmployeeEarningRepository} from "../interfaces/IEmployeeEarningRepository";
 import {EmployeeEarningModel} from "../../business/models/EmployeeEarningModel";
 import {ResultSetHeader, RowDataPacket} from "mysql2";
 import {RevenueModel} from "../../business/models/RevenueModel";
 
+/**
+ * EmployeeEarningRepository class.
+ */
 export class EmployeeEarningRepository extends BaseRepository implements IEmployeeEarningRepository {
     public async findAll(params: {
         limit?: number;

--- a/src/data/repositories/ModelRepository.ts
+++ b/src/data/repositories/ModelRepository.ts
@@ -1,8 +1,14 @@
+/**
+ * ModelRepository module.
+ */
 import {BaseRepository} from "./BaseRepository";
 import {IModelRepository} from "../interfaces/IModelRepository";
 import {ModelModel} from "../../business/models/ModelModel";
 import {ResultSetHeader, RowDataPacket} from "mysql2";
 
+/**
+ * ModelRepository class.
+ */
 export class ModelRepository extends BaseRepository implements IModelRepository {
     public async findAll(): Promise<ModelModel[]> {
         const rows = await this.execute<RowDataPacket[]>(

--- a/src/data/repositories/ShiftRepository.ts
+++ b/src/data/repositories/ShiftRepository.ts
@@ -1,9 +1,15 @@
+/**
+ * ShiftRepository module.
+ */
 import {BaseRepository} from "./BaseRepository";
 import {IShiftRepository} from "../interfaces/IShiftRepository";
 import {ShiftModel} from "../../business/models/ShiftModel";
 import {ShiftStatus} from "../../rename/types";
 import {ResultSetHeader, RowDataPacket} from "mysql2";
 
+/**
+ * ShiftRepository class.
+ */
 export class ShiftRepository extends BaseRepository implements IShiftRepository {
     public async findAll(): Promise<ShiftModel[]> {
         const rows = await this.execute<RowDataPacket[]>(

--- a/src/data/repositories/UserRepository.ts
+++ b/src/data/repositories/UserRepository.ts
@@ -1,9 +1,15 @@
+/**
+ * UserRepository module.
+ */
 import {BaseRepository} from "./BaseRepository";
 import {IUserRepository} from "../interfaces/IUserRepository";
 import {UserModel} from "../../business/models/UserModel";
 import {Role} from "../../rename/types";
 import {ResultSetHeader, RowDataPacket} from "mysql2";
 
+/**
+ * UserRepository class.
+ */
 export class UserRepository extends BaseRepository implements IUserRepository {
     public async findAll(): Promise<UserModel[]> {
         const rows = await this.execute<RowDataPacket[]>(

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -1,15 +1,45 @@
+/**
+ * auth module.
+ */
 // src/middleware/auth.ts
 import { Request, Response, NextFunction } from "express";
 import jwt from "jsonwebtoken";
 
+/**
+ * Express request extended with an optional authenticated user ID.
+ */
+/**
+ * AuthenticatedRequest interface.
+ */
 export interface AuthenticatedRequest extends Request {
+    /**
+     * Identifier of the authenticated user if a valid token is provided.
+     */
     userId?: bigint;
 }
 
+/**
+ * Structure of the JWT payload expected by the application.
+ */
+/**
+ * JwtPayload interface.
+ */
 export interface JwtPayload {
+    /**
+     * Identifier of the authenticated user encoded as a string.
+     */
     userId: string;
 }
 
+/**
+ * Middleware that verifies a JWT token from the `Authorization` header and
+ * attaches the corresponding `userId` to the request object. Responds with
+ * `401` if no token is provided or `403` if the token is invalid.
+ *
+ * @param req - Express request possibly containing a JWT token.
+ * @param res - Express response used to send error codes.
+ * @param next - Callback to pass control to the next middleware.
+ */
 export const authenticateToken = (req: AuthenticatedRequest, res: Response, next: NextFunction) => {
     const authHeader = req.headers['authorization'];
     const token = authHeader && authHeader.split(' ')[1];

--- a/src/rename/types.ts
+++ b/src/rename/types.ts
@@ -1,3 +1,6 @@
+/**
+ * types module.
+ */
 export type Role = "manager" | "chatter";
 export type CurrencySymbol = "€";
 export type ChatterStatus = "active" | "inactive"; // extend if you add more states

--- a/src/routes/ChatterRoute.ts
+++ b/src/routes/ChatterRoute.ts
@@ -1,3 +1,6 @@
+/**
+ * ChatterRoute module.
+ */
 import {Router} from "express";
 import {authenticateToken} from "../middleware/auth";
 import {ChatterController} from "../controllers/ChatterController";

--- a/src/routes/CommissionRoute.ts
+++ b/src/routes/CommissionRoute.ts
@@ -1,3 +1,6 @@
+/**
+ * CommissionRoute module.
+ */
 import { Router } from "express";
 import { authenticateToken } from "../middleware/auth";
 import { CommissionController } from "../controllers/CommissionController";

--- a/src/routes/EmployeeEarningRoute.ts
+++ b/src/routes/EmployeeEarningRoute.ts
@@ -1,3 +1,6 @@
+/**
+ * EmployeeEarningRoute module.
+ */
 import {Router} from "express";
 import {authenticateToken} from "../middleware/auth";
 import {EmployeeEarningController} from "../controllers/EmployeeEarningController";

--- a/src/routes/ModelRoute.ts
+++ b/src/routes/ModelRoute.ts
@@ -1,3 +1,6 @@
+/**
+ * ModelRoute module.
+ */
 import {Router} from "express";
 import {authenticateToken} from "../middleware/auth";
 import {ModelController} from "../controllers/ModelController";

--- a/src/routes/RevenueRoute.ts
+++ b/src/routes/RevenueRoute.ts
@@ -1,3 +1,6 @@
+/**
+ * RevenueRoute module.
+ */
 import {Router} from "express";
 import {authenticateToken} from "../middleware/auth";
 import {RevenueController} from "../controllers/RevenueController";

--- a/src/routes/ShiftRoute.ts
+++ b/src/routes/ShiftRoute.ts
@@ -1,3 +1,6 @@
+/**
+ * ShiftRoute module.
+ */
 import {Router} from "express";
 import {authenticateToken} from "../middleware/auth";
 import {ShiftController} from "../controllers/ShiftController";

--- a/src/routes/UserRoute.ts
+++ b/src/routes/UserRoute.ts
@@ -1,7 +1,13 @@
+/**
+ * UserRoute module.
+ */
 import { Router } from "express";
 import { authenticateToken } from "../middleware/auth";
-import {UserController} from "../controllers/UserController";
+import { UserController } from "../controllers/UserController";
 
+/**
+ * Router exposing user-related endpoints.
+ */
 const router = Router();
 const controller = new UserController();
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,3 +1,8 @@
+/**
+ * Initializes the Express application, configures middleware and routes, and
+ * starts the HTTP server. The configured `app` instance is exported for
+ * testing or serverless environments.
+ */
 import "./config/timezone";
 import "reflect-metadata";
 import "./container";

--- a/src/tasks/syncTransactionEarnings.ts
+++ b/src/tasks/syncTransactionEarnings.ts
@@ -1,3 +1,6 @@
+/**
+ * syncTransactionEarnings module.
+ */
 import '../config/timezone';
 import 'reflect-metadata';
 import '../container';

--- a/src/tasks/syncUnlockEarnings.ts
+++ b/src/tasks/syncUnlockEarnings.ts
@@ -1,3 +1,6 @@
+/**
+ * syncUnlockEarnings module.
+ */
 import '../config/timezone';
 import 'reflect-metadata';
 import '../container';

--- a/src/utils/time.ts
+++ b/src/utils/time.ts
@@ -1,3 +1,9 @@
+/**
+ * time module.
+ */
+/**
+ * toLocalDateString function.
+ */
 export function toLocalDateString(date: Date): string {
   const y = date.getFullYear();
   const m = String(date.getMonth() + 1).padStart(2, '0');
@@ -5,6 +11,9 @@ export function toLocalDateString(date: Date): string {
   return `${y}-${m}-${d}`;
 }
 
+/**
+ * toLocalISOString function.
+ */
 export function toLocalISOString(date: Date): string {
   const y = date.getFullYear();
   const m = String(date.getMonth() + 1).padStart(2, '0');


### PR DESCRIPTION
## Summary
- document auth middleware and routing with JSDoc
- add jsdoc config and npm script to generate docs
- introduce project README
- add basic JSDoc annotations across modules and include jsdoc dependency

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm run docs` *(fails: jsdoc not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c15a523280832782cb4af2d3676e34