### PR TITLE
feat: add filters to employee earnings total count

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ token) responses.
 
 - `GET /api/employee-earnings` – list earnings; responds with `{ earnings, total }` where `total` is the total number of matching records.
 - `GET /api/employee-earnings/leaderboard` – leaderboard summary.
+- `GET /api/employee-earnings/totalCount` – total number of earnings; supports `chatterId`, `type` and `modelId` query params.
 - `GET /api/employee-earnings/chatter/:id` – earnings for a chatter.
 - `POST /api/employee-earnings/sync` – synchronize earnings data.
 - `GET /api/employee-earnings/:id` – fetch an earning record.

--- a/src/business/services/EmployeeEarningService.ts
+++ b/src/business/services/EmployeeEarningService.ts
@@ -38,8 +38,8 @@ export class EmployeeEarningService {
         return this.earningRepo.findAll(params);
     }
 
-    public async totalCount(): Promise<number> {
-        return this.earningRepo.totalCount();
+    public async totalCount(params: { chatterId?: number; type?: string; modelId?: number } = {}): Promise<number> {
+        return this.earningRepo.totalCount(params);
     }
 
     /**

--- a/src/controllers/EmployeeEarningController.ts
+++ b/src/controllers/EmployeeEarningController.ts
@@ -42,7 +42,10 @@ export class EmployeeEarningController {
      */
     public async totalCount(req: Request, res: Response): Promise<void> {
         try {
-            const total = await this.service.totalCount();
+            const chatterId = req.query.chatterId ? Number(req.query.chatterId) : undefined;
+            const type = req.query.type ? String(req.query.type) : undefined;
+            const modelId = req.query.modelId ? Number(req.query.modelId) : undefined;
+            const total = await this.service.totalCount({chatterId, type, modelId});
             res.json({total});
         } catch (err) {
             console.error(err);

--- a/src/data/interfaces/IEmployeeEarningRepository.ts
+++ b/src/data/interfaces/IEmployeeEarningRepository.ts
@@ -14,7 +14,7 @@ export interface IEmployeeEarningRepository {
         chatterId?: number;
         type?: string;
     }): Promise<EmployeeEarningModel[]>;
-    totalCount(): Promise<number>;
+    totalCount(params?: { chatterId?: number; type?: string; modelId?: number }): Promise<number>;
     findById(id: string): Promise<EmployeeEarningModel | null>;
     create(data: {
         id?: string;

--- a/src/data/repositories/EmployeeEarningRepository.ts
+++ b/src/data/repositories/EmployeeEarningRepository.ts
@@ -50,10 +50,28 @@ export class EmployeeEarningRepository extends BaseRepository implements IEmploy
         return rows.map(EmployeeEarningModel.fromRow);
     }
 
-    public async totalCount(): Promise<number> {
+    public async totalCount(params: { chatterId?: number; type?: string; modelId?: number } = {}): Promise<number> {
+        const conditions: string[] = [];
+        const values: any[] = [];
+
+        if (params.chatterId !== undefined) {
+            conditions.push("chatter_id = ?");
+            values.push(params.chatterId);
+        }
+        if (params.type !== undefined) {
+            conditions.push("type = ?");
+            values.push(params.type);
+        }
+        if (params.modelId !== undefined) {
+            conditions.push("model_id = ?");
+            values.push(params.modelId);
+        }
+
+        const whereClause = conditions.length ? " WHERE " + conditions.join(" AND ") : "";
+
         const rows = await this.execute<RowDataPacket[]>(
-            "SELECT COUNT(*) as total FROM employee_earnings",
-            []
+            `SELECT COUNT(*) as total FROM employee_earnings${whereClause}`,
+            values
         );
         return Number(rows[0].total || 0);
     }


### PR DESCRIPTION
## Summary
- allow filtering the employee earnings total count by chatter, type, or model
- document `totalCount` endpoint and supported query params

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: ESLint couldn't find an eslint.config file)*
- `npm run build` *(fails: TypeScript error in auth middleware)*

------
https://chatgpt.com/codex/tasks/task_e_68c689a55de4832793c0a581a58380ad