### PR TITLE
feat: add date filter to employee earnings endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,9 @@ token) responses.
 
 ### Employee Earnings
 
-- `GET /api/employee-earnings` – list earnings; responds with `{ earnings, total }` where `total` is the total number of matching records.
+- `GET /api/employee-earnings` – list earnings; supports `chatterId`, `type` and `date` query params; responds with `{ earnings, total }` where `total` is the total number of matching records.
 - `GET /api/employee-earnings/leaderboard` – leaderboard summary.
+- `GET /api/employee-earnings/totalCount` – total number of earnings; supports `chatterId`, `type`, `modelId` and `date` query params.
 - `GET /api/employee-earnings/chatter/:id` – earnings for a chatter.
 - `POST /api/employee-earnings/sync` – synchronize earnings data.
 - `GET /api/employee-earnings/:id` – fetch an earning record.

--- a/src/business/services/EmployeeEarningService.ts
+++ b/src/business/services/EmployeeEarningService.ts
@@ -30,6 +30,7 @@ export class EmployeeEarningService {
         offset?: number;
         chatterId?: number;
         type?: string;
+        date?: Date;
     } = {}): Promise<EmployeeEarningModel[]> {
         if ((params.offset ?? 0) <= 0) {
             console.log("Syncing recent F2F transactions...");
@@ -38,8 +39,8 @@ export class EmployeeEarningService {
         return this.earningRepo.findAll(params);
     }
 
-    public async totalCount(): Promise<number> {
-        return this.earningRepo.totalCount();
+    public async totalCount(params: { chatterId?: number; type?: string; modelId?: number; date?: Date } = {}): Promise<number> {
+        return this.earningRepo.totalCount(params);
     }
 
     /**

--- a/src/controllers/EmployeeEarningController.ts
+++ b/src/controllers/EmployeeEarningController.ts
@@ -27,7 +27,16 @@ export class EmployeeEarningController {
             const offset = req.query.offset ? Number(req.query.offset) : undefined;
             const chatterId = req.query.chatterId ? Number(req.query.chatterId) : undefined;
             const type = req.query.type ? String(req.query.type) : undefined;
-            const earnings = await this.service.getAll({limit, offset, chatterId, type});
+            const dateStr = req.query.date ? String(req.query.date) : undefined;
+            let date: Date | undefined;
+            if (dateStr) {
+                date = new Date(dateStr);
+                if (isNaN(date.getTime())) {
+                    res.status(400).send("Invalid date");
+                    return;
+                }
+            }
+            const earnings = await this.service.getAll({limit, offset, chatterId, type, date});
             res.json(earnings.map(e => e.toJSON()));
         } catch (err) {
             console.error(err);
@@ -42,7 +51,19 @@ export class EmployeeEarningController {
      */
     public async totalCount(req: Request, res: Response): Promise<void> {
         try {
-            const total = await this.service.totalCount();
+            const chatterId = req.query.chatterId ? Number(req.query.chatterId) : undefined;
+            const type = req.query.type ? String(req.query.type) : undefined;
+            const modelId = req.query.modelId ? Number(req.query.modelId) : undefined;
+            const dateStr = req.query.date ? String(req.query.date) : undefined;
+            let date: Date | undefined;
+            if (dateStr) {
+                date = new Date(dateStr);
+                if (isNaN(date.getTime())) {
+                    res.status(400).send("Invalid date");
+                    return;
+                }
+            }
+            const total = await this.service.totalCount({chatterId, type, modelId, date});
             res.json({total});
         } catch (err) {
             console.error(err);

--- a/src/data/interfaces/IEmployeeEarningRepository.ts
+++ b/src/data/interfaces/IEmployeeEarningRepository.ts
@@ -13,8 +13,9 @@ export interface IEmployeeEarningRepository {
         offset?: number;
         chatterId?: number;
         type?: string;
+        date?: Date;
     }): Promise<EmployeeEarningModel[]>;
-    totalCount(): Promise<number>;
+    totalCount(params?: { chatterId?: number; type?: string; modelId?: number; date?: Date }): Promise<number>;
     findById(id: string): Promise<EmployeeEarningModel | null>;
     create(data: {
         id?: string;

--- a/src/data/repositories/EmployeeEarningRepository.ts
+++ b/src/data/repositories/EmployeeEarningRepository.ts
@@ -16,6 +16,7 @@ export class EmployeeEarningRepository extends BaseRepository implements IEmploy
         offset?: number;
         chatterId?: number;
         type?: string;
+        date?: Date;
     } = {}): Promise<EmployeeEarningModel[]> {
         const baseQuery = "FROM employee_earnings";
         const conditions: string[] = [];
@@ -28,6 +29,10 @@ export class EmployeeEarningRepository extends BaseRepository implements IEmploy
         if (params.type !== undefined) {
             conditions.push("type = ?");
             values.push(params.type);
+        }
+        if (params.date !== undefined) {
+            conditions.push("DATE(date) = ?");
+            values.push(params.date.toISOString().slice(0, 10));
         }
 
         const whereClause = conditions.length ? " WHERE " + conditions.join(" AND ") : "";
@@ -50,10 +55,32 @@ export class EmployeeEarningRepository extends BaseRepository implements IEmploy
         return rows.map(EmployeeEarningModel.fromRow);
     }
 
-    public async totalCount(): Promise<number> {
+    public async totalCount(params: { chatterId?: number; type?: string; modelId?: number; date?: Date } = {}): Promise<number> {
+        const conditions: string[] = [];
+        const values: any[] = [];
+
+        if (params.chatterId !== undefined) {
+            conditions.push("chatter_id = ?");
+            values.push(params.chatterId);
+        }
+        if (params.type !== undefined) {
+            conditions.push("type = ?");
+            values.push(params.type);
+        }
+        if (params.modelId !== undefined) {
+            conditions.push("model_id = ?");
+            values.push(params.modelId);
+        }
+        if (params.date !== undefined) {
+            conditions.push("DATE(date) = ?");
+            values.push(params.date.toISOString().slice(0, 10));
+        }
+
+        const whereClause = conditions.length ? " WHERE " + conditions.join(" AND ") : "";
+
         const rows = await this.execute<RowDataPacket[]>(
-            "SELECT COUNT(*) as total FROM employee_earnings",
-            []
+            `SELECT COUNT(*) as total FROM employee_earnings${whereClause}`,
+            values
         );
         return Number(rows[0].total || 0);
     }


### PR DESCRIPTION
## Summary
- support optional `date` query parameter on `/api/employee-earnings` and `/api/employee-earnings/totalCount`
- propagate `date` filter through service and repository layers
- document `date` query parameter for employee earnings endpoints

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: ESLint couldn't find an eslint.config file)*
- `npm run build` *(fails: auth middleware type mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_68c689a55de4832793c0a581a58380ad