### PR TITLE
Extend commissions endpoints and automate shift payouts

### DIFF
--- a/src/business/models/CommissionModel.ts
+++ b/src/business/models/CommissionModel.ts
@@ -10,51 +10,63 @@ export class CommissionModel {
     constructor(
         private _id: number,
         private _chatterId: number,
-        private _periodStart: Date,
-        private _periodEnd: Date,
+        private _shiftId: number | null,
+        private _commissionDate: Date,
         private _earnings: number,
         private _commissionRate: number,
         private _commission: number,
+        private _bonus: number,
+        private _totalPayout: number,
         private _status: CommissionStatus,
         private _createdAt: Date,
+        private _updatedAt: Date | null,
     ) {}
 
     public toJSON(): Record<string, any> {
         return {
             id: this.id,
             chatterId: this.chatterId,
-            periodStart: this.periodStart,
-            periodEnd: this.periodEnd,
+            shiftId: this.shiftId,
+            commissionDate: this.commissionDate,
             earnings: this.earnings,
             commissionRate: this.commissionRate,
             commission: this.commission,
+            bonus: this.bonus,
+            totalPayout: this.totalPayout,
             status: this.status,
             createdAt: this.createdAt,
+            updatedAt: this.updatedAt,
         };
     }
 
     // Getters
     get id(): number { return this._id; }
     get chatterId(): number { return this._chatterId; }
-    get periodStart(): Date { return this._periodStart; }
-    get periodEnd(): Date { return this._periodEnd; }
+    get shiftId(): number | null { return this._shiftId; }
+    get commissionDate(): Date { return this._commissionDate; }
     get earnings(): number { return this._earnings; }
     get commissionRate(): number { return this._commissionRate; }
     get commission(): number { return this._commission; }
+    get bonus(): number { return this._bonus; }
+    get totalPayout(): number { return this._totalPayout; }
     get status(): CommissionStatus { return this._status; }
     get createdAt(): Date { return this._createdAt; }
+    get updatedAt(): Date | null { return this._updatedAt; }
 
     static fromRow(r: any): CommissionModel {
         return new CommissionModel(
             Number(r.id),
             Number(r.chatter_id),
-            r.period_start,
-            r.period_end,
+            r.shift_id != null ? Number(r.shift_id) : null,
+            r.commission_date ?? r.period_start ?? r.period_end ?? r.created_at,
             Number(r.earnings),
             Number(r.commission_rate),
             Number(r.commission),
+            Number(r.bonus ?? 0),
+            Number(r.total_payout ?? Number(r.commission ?? 0) + Number(r.bonus ?? 0)),
             (r.status ?? "pending") as CommissionStatus,
             r.created_at,
+            r.updated_at ?? null,
         );
     }
 }

--- a/src/business/services/CommissionService.ts
+++ b/src/business/services/CommissionService.ts
@@ -5,24 +5,66 @@ import { inject, injectable } from "tsyringe";
 import { ICommissionRepository } from "../../data/interfaces/ICommissionRepository";
 import { CommissionModel } from "../models/CommissionModel";
 import { CommissionStatus } from "../../rename/types";
+import { IEmployeeEarningRepository } from "../../data/interfaces/IEmployeeEarningRepository";
+import { IChatterRepository } from "../../data/interfaces/IChatterRepository";
+import { ShiftModel } from "../models/ShiftModel";
+
+type CommissionQueryParams = {
+    limit?: number;
+    offset?: number;
+    chatterId?: number;
+    date?: Date;
+    from?: Date;
+    to?: Date;
+};
+
+type CommissionCreateInput = {
+    chatterId: number;
+    shiftId?: number | null;
+    commissionDate: Date;
+    earnings: number;
+    commissionRate: number;
+    commission: number;
+    bonus?: number;
+    totalPayout?: number;
+    status: CommissionStatus;
+};
+
+type CommissionUpdateInput = {
+    chatterId?: number;
+    shiftId?: number | null;
+    commissionDate?: Date;
+    earnings?: number;
+    commissionRate?: number;
+    commission?: number;
+    bonus?: number;
+    totalPayout?: number;
+    status?: CommissionStatus;
+};
 
 /**
  * Service managing commissions for chatters.
  */
 @injectable()
-/**
- * CommissionService class.
- */
 export class CommissionService {
     constructor(
-        @inject("ICommissionRepository") private commissionRepo: ICommissionRepository
+        @inject("ICommissionRepository") private commissionRepo: ICommissionRepository,
+        @inject("IEmployeeEarningRepository") private earningRepo: IEmployeeEarningRepository,
+        @inject("IChatterRepository") private chatterRepo: IChatterRepository,
     ) {}
 
     /**
-     * Retrieves all commission records.
+     * Retrieves commission records using optional filters and pagination.
      */
-    public async getAll(): Promise<CommissionModel[]> {
-        return this.commissionRepo.findAll();
+    public async getAll(params: CommissionQueryParams = {}): Promise<CommissionModel[]> {
+        return this.commissionRepo.findAll(params);
+    }
+
+    /**
+     * Retrieves the total count for commission records using the provided filters.
+     */
+    public async totalCount(params: CommissionQueryParams = {}): Promise<number> {
+        return this.commissionRepo.totalCount(params);
     }
 
     /**
@@ -37,16 +79,10 @@ export class CommissionService {
      * Creates a new commission record.
      * @param data Commission data.
      */
-    public async create(data: {
-        chatterId: number;
-        periodStart: Date;
-        periodEnd: Date;
-        earnings: number;
-        commissionRate: number;
-        commission: number;
-        status: CommissionStatus;
-    }): Promise<CommissionModel> {
-        return this.commissionRepo.create(data);
+    public async create(data: CommissionCreateInput): Promise<CommissionModel> {
+        const bonus = data.bonus ?? 0;
+        const totalPayout = data.totalPayout ?? data.commission + bonus;
+        return this.commissionRepo.create({ ...data, bonus, totalPayout });
     }
 
     /**
@@ -54,15 +90,7 @@ export class CommissionService {
      * @param id Commission identifier.
      * @param data Partial commission data.
      */
-    public async update(id: number, data: {
-        chatterId?: number;
-        periodStart?: Date;
-        periodEnd?: Date;
-        earnings?: number;
-        commissionRate?: number;
-        commission?: number;
-        status?: CommissionStatus;
-    }): Promise<CommissionModel | null> {
+    public async update(id: number, data: CommissionUpdateInput): Promise<CommissionModel | null> {
         return this.commissionRepo.update(id, data);
     }
 
@@ -72,5 +100,63 @@ export class CommissionService {
      */
     public async delete(id: number): Promise<void> {
         await this.commissionRepo.delete(id);
+    }
+
+    /**
+     * Ensures a commission exists for the provided shift, creating it if necessary.
+     * @param shift Completed shift information.
+     */
+    public async ensureCommissionForShift(shift: ShiftModel): Promise<void> {
+        const chatterId = shift.chatterId;
+        if (!chatterId) return;
+
+        const existing = await this.commissionRepo.findByShiftId(shift.id);
+        if (existing) {
+            return;
+        }
+
+        const [earnings, chatter] = await Promise.all([
+            this.earningRepo.findAll({ shiftId: shift.id }),
+            this.chatterRepo.findById(chatterId),
+        ]);
+
+        const earningsTotal = earnings.reduce((sum, earning) => sum + earning.amount, 0);
+        const commissionRate = chatter?.commissionRate ?? 0;
+        const commissionAmount = this.roundCurrency(earningsTotal * commissionRate);
+
+        await this.commissionRepo.create({
+            chatterId,
+            shiftId: shift.id,
+            commissionDate: this.resolveCommissionDate(shift.date),
+            earnings: this.roundCurrency(earningsTotal),
+            commissionRate,
+            commission: commissionAmount,
+            bonus: 0,
+            totalPayout: commissionAmount,
+            status: "pending",
+        });
+    }
+
+    private roundCurrency(value: number): number {
+        return Math.round((value + Number.EPSILON) * 100) / 100;
+    }
+
+    private resolveCommissionDate(input: any): Date {
+        if (input instanceof Date) {
+            return input;
+        }
+        if (typeof input === "string") {
+            const parsed = new Date(input);
+            if (!Number.isNaN(parsed.getTime())) {
+                return parsed;
+            }
+        }
+        if (input && typeof input === "object" && typeof input.toString === "function") {
+            const parsed = new Date(input.toString());
+            if (!Number.isNaN(parsed.getTime())) {
+                return parsed;
+            }
+        }
+        return new Date();
     }
 }

--- a/src/data/interfaces/ICommissionRepository.ts
+++ b/src/data/interfaces/ICommissionRepository.ts
@@ -8,25 +8,43 @@ import { CommissionStatus } from "../../rename/types";
  * ICommissionRepository interface.
  */
 export interface ICommissionRepository {
-    findAll(): Promise<CommissionModel[]>;
+    findAll(params?: {
+        limit?: number;
+        offset?: number;
+        chatterId?: number;
+        date?: Date;
+        from?: Date;
+        to?: Date;
+    }): Promise<CommissionModel[]>;
     findById(id: number): Promise<CommissionModel | null>;
+    findByShiftId(shiftId: number): Promise<CommissionModel | null>;
     create(data: {
         chatterId: number;
-        periodStart: Date;
-        periodEnd: Date;
+        shiftId?: number | null;
+        commissionDate: Date;
         earnings: number;
         commissionRate: number;
         commission: number;
+        bonus?: number;
+        totalPayout?: number;
         status: CommissionStatus;
     }): Promise<CommissionModel>;
     update(id: number, data: {
         chatterId?: number;
-        periodStart?: Date;
-        periodEnd?: Date;
+        shiftId?: number | null;
+        commissionDate?: Date;
         earnings?: number;
         commissionRate?: number;
         commission?: number;
+        bonus?: number;
+        totalPayout?: number;
         status?: CommissionStatus;
     }): Promise<CommissionModel | null>;
+    totalCount(params?: {
+        chatterId?: number;
+        date?: Date;
+        from?: Date;
+        to?: Date;
+    }): Promise<number>;
     delete(id: number): Promise<void>;
 }

--- a/src/data/repositories/CommissionRepository.ts
+++ b/src/data/repositories/CommissionRepository.ts
@@ -11,34 +11,120 @@ import { ResultSetHeader, RowDataPacket } from "mysql2";
  * CommissionRepository class.
  */
 export class CommissionRepository extends BaseRepository implements ICommissionRepository {
-    public async findAll(): Promise<CommissionModel[]> {
-        const rows = await this.execute<RowDataPacket[]>(
-            "SELECT id, chatter_id, period_start, period_end, earnings, commission_rate, commission, status, created_at FROM commissions",
-            []
-        );
+    private buildFilters(params: {
+        chatterId?: number;
+        date?: Date;
+        from?: Date;
+        to?: Date;
+    } = {}): { whereClause: string; values: any[] } {
+        const conditions: string[] = [];
+        const values: any[] = [];
+
+        if (params.chatterId !== undefined) {
+            conditions.push("chatter_id = ?");
+            values.push(params.chatterId);
+        }
+        if (params.date !== undefined) {
+            conditions.push("DATE(commission_date) = ?");
+            values.push(params.date.toISOString().slice(0, 10));
+        }
+        if (params.from !== undefined) {
+            conditions.push("commission_date >= ?");
+            values.push(params.from);
+        }
+        if (params.to !== undefined) {
+            conditions.push("commission_date <= ?");
+            values.push(params.to);
+        }
+
+        const whereClause = conditions.length ? ` WHERE ${conditions.join(" AND ")}` : "";
+        return { whereClause, values };
+    }
+
+    public async findAll(params: {
+        limit?: number;
+        offset?: number;
+        chatterId?: number;
+        date?: Date;
+        from?: Date;
+        to?: Date;
+    } = {}): Promise<CommissionModel[]> {
+        const { whereClause, values } = this.buildFilters(params);
+        let query = `SELECT id, chatter_id, shift_id, commission_date, earnings, commission_rate, commission, bonus, total_payout, status, created_at, updated_at FROM commissions${whereClause} ORDER BY commission_date DESC, created_at DESC`;
+        const dataValues = [...values];
+
+        if (params.limit !== undefined) {
+            query += " LIMIT ?";
+            dataValues.push(params.limit);
+            if (params.offset !== undefined) {
+                query += " OFFSET ?";
+                dataValues.push(params.offset);
+            }
+        } else if (params.offset !== undefined) {
+            query += " LIMIT 18446744073709551615 OFFSET ?";
+            dataValues.push(params.offset);
+        }
+
+        const rows = await this.execute<RowDataPacket[]>(query, dataValues);
         return rows.map(CommissionModel.fromRow);
+    }
+
+    public async totalCount(params: {
+        chatterId?: number;
+        date?: Date;
+        from?: Date;
+        to?: Date;
+    } = {}): Promise<number> {
+        const { whereClause, values } = this.buildFilters(params);
+        const rows = await this.execute<RowDataPacket[]>(
+            `SELECT COUNT(*) as total FROM commissions${whereClause}`,
+            values,
+        );
+        return rows.length ? Number(rows[0].total || 0) : 0;
     }
 
     public async findById(id: number): Promise<CommissionModel | null> {
         const rows = await this.execute<RowDataPacket[]>(
-            "SELECT id, chatter_id, period_start, period_end, earnings, commission_rate, commission, status, created_at FROM commissions WHERE id = ?",
+            "SELECT id, chatter_id, shift_id, commission_date, earnings, commission_rate, commission, bonus, total_payout, status, created_at, updated_at FROM commissions WHERE id = ?",
             [id]
+        );
+        return rows.length ? CommissionModel.fromRow(rows[0]) : null;
+    }
+
+    public async findByShiftId(shiftId: number): Promise<CommissionModel | null> {
+        const rows = await this.execute<RowDataPacket[]>(
+            "SELECT id, chatter_id, shift_id, commission_date, earnings, commission_rate, commission, bonus, total_payout, status, created_at, updated_at FROM commissions WHERE shift_id = ?",
+            [shiftId]
         );
         return rows.length ? CommissionModel.fromRow(rows[0]) : null;
     }
 
     public async create(data: {
         chatterId: number;
-        periodStart: Date;
-        periodEnd: Date;
+        shiftId?: number | null;
+        commissionDate: Date;
         earnings: number;
         commissionRate: number;
         commission: number;
+        bonus?: number;
+        totalPayout?: number;
         status: CommissionStatus;
     }): Promise<CommissionModel> {
+        const bonus = data.bonus ?? 0;
+        const totalPayout = data.totalPayout ?? data.commission + bonus;
         const result = await this.execute<ResultSetHeader>(
-            "INSERT INTO commissions (chatter_id, period_start, period_end, earnings, commission_rate, commission, status) VALUES (?, ?, ?, ?, ?, ?, ?)",
-            [data.chatterId, data.periodStart, data.periodEnd, data.earnings, data.commissionRate, data.commission, data.status]
+            "INSERT INTO commissions (chatter_id, shift_id, commission_date, earnings, commission_rate, commission, bonus, total_payout, status) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            [
+                data.chatterId,
+                data.shiftId ?? null,
+                data.commissionDate,
+                data.earnings,
+                data.commissionRate,
+                data.commission,
+                bonus,
+                totalPayout,
+                data.status,
+            ]
         );
         const insertedId = Number(result.insertId);
         const created = await this.findById(insertedId);
@@ -48,24 +134,33 @@ export class CommissionRepository extends BaseRepository implements ICommissionR
 
     public async update(id: number, data: {
         chatterId?: number;
-        periodStart?: Date;
-        periodEnd?: Date;
+        shiftId?: number | null;
+        commissionDate?: Date;
         earnings?: number;
         commissionRate?: number;
         commission?: number;
+        bonus?: number;
+        totalPayout?: number;
         status?: CommissionStatus;
     }): Promise<CommissionModel | null> {
         const existing = await this.findById(id);
         if (!existing) return null;
+        const bonus = data.bonus ?? existing.bonus;
+        const shouldRecalculate = data.totalPayout === undefined && (data.commission !== undefined || data.bonus !== undefined);
+        const totalPayout = data.totalPayout ?? (shouldRecalculate
+            ? (data.commission ?? existing.commission) + (data.bonus ?? existing.bonus)
+            : existing.totalPayout);
         await this.execute<ResultSetHeader>(
-            "UPDATE commissions SET chatter_id = ?, period_start = ?, period_end = ?, earnings = ?, commission_rate = ?, commission = ?, status = ? WHERE id = ?",
+            "UPDATE commissions SET chatter_id = ?, shift_id = ?, commission_date = ?, earnings = ?, commission_rate = ?, commission = ?, bonus = ?, total_payout = ?, status = ? WHERE id = ?",
             [
                 data.chatterId ?? existing.chatterId,
-                data.periodStart ?? existing.periodStart,
-                data.periodEnd ?? existing.periodEnd,
+                data.shiftId !== undefined ? data.shiftId : existing.shiftId,
+                data.commissionDate ?? existing.commissionDate,
                 data.earnings ?? existing.earnings,
                 data.commissionRate ?? existing.commissionRate,
                 data.commission ?? existing.commission,
+                bonus,
+                totalPayout,
                 data.status ?? existing.status,
                 id,
             ]

--- a/src/routes/CommissionRoute.ts
+++ b/src/routes/CommissionRoute.ts
@@ -9,6 +9,7 @@ const router = Router();
 const controller = new CommissionController();
 
 router.get("/", authenticateToken, controller.getAll.bind(controller));
+router.get("/totalCount", authenticateToken, controller.getTotalCount.bind(controller));
 router.get("/:id", authenticateToken, controller.getById.bind(controller));
 router.post("/", authenticateToken, controller.create.bind(controller));
 router.put("/:id", authenticateToken, controller.update.bind(controller));


### PR DESCRIPTION
## Summary
- update commission model, repository, and service to expose commissionDate, payout totals, filtering, and pagination metadata
- add `/api/commissions/totalCount` and enhance the commissions controller to accept limit, offset, chatterId, and date range filters
- trigger automatic commission creation when a shift is clocked out and guard against duplicate per-shift records

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c963ea5608832788866aa670bead13