### PR TITLE
Enhance shift scheduling APIs

### DIFF
--- a/src/controllers/ShiftController.ts
+++ b/src/controllers/ShiftController.ts
@@ -4,7 +4,9 @@
 import {Request, Response} from "express";
 import {container} from "tsyringe";
 import {ShiftService} from "../business/services/ShiftService";
-import {ShiftModel} from "../business/models/ShiftModel";
+import {ShiftStatus} from "../rename/types";
+
+const VALID_SHIFT_STATUSES: ShiftStatus[] = ["scheduled", "active", "completed", "cancelled"];
 
 /**
  * Controller handling shift scheduling and tracking.
@@ -22,9 +24,36 @@ export class ShiftController {
      * @param _req Express request object.
      * @param res Express response object.
      */
-    public async getAll(_req: Request, res: Response): Promise<void> {
+    public async getAll(req: Request, res: Response): Promise<void> {
         try {
-            const shifts = await this.service.getAll();
+            const {from, to, chatterId} = req.query;
+
+            const parsedFrom = typeof from === "string" ? new Date(from) : undefined;
+            if (parsedFrom && Number.isNaN(parsedFrom.getTime())) {
+                res.status(400).send("Invalid from parameter");
+                return;
+            }
+
+            const parsedTo = typeof to === "string" ? new Date(to) : undefined;
+            if (parsedTo && Number.isNaN(parsedTo.getTime())) {
+                res.status(400).send("Invalid to parameter");
+                return;
+            }
+
+            let parsedChatterId: number | undefined;
+            if (typeof chatterId === "string" && chatterId.trim() !== "") {
+                parsedChatterId = Number(chatterId);
+                if (Number.isNaN(parsedChatterId)) {
+                    res.status(400).send("Invalid chatterId parameter");
+                    return;
+                }
+            }
+
+            const shifts = await this.service.getAll({
+                from: parsedFrom,
+                to: parsedTo,
+                chatterId: parsedChatterId,
+            });
             res.json(shifts.map(s => s.toJSON()));
         } catch (err) {
             console.error(err);
@@ -59,16 +88,94 @@ export class ShiftController {
      */
     public async create(req: Request, res: Response): Promise<void> {
         try {
-            const data = {
-                ...req.body,
-                modelIds: Array.isArray(req.body.modelIds) ? req.body.modelIds.map((n: any) => Number(n)) : [],
+            const repeatWeeklyRaw = req.body.repeatWeekly;
+            const repeatWeekly = repeatWeeklyRaw === true || repeatWeeklyRaw === "true";
+            const repeatWeeksRaw = req.body.repeatWeeks;
+            const repeatWeeksNumber = repeatWeeksRaw === undefined ? 0 : Number(repeatWeeksRaw);
+
+            if (Number.isNaN(repeatWeeksNumber) || repeatWeeksNumber < 0) {
+                res.status(400).send("Invalid repeatWeeks value");
+                return;
+            }
+            const repeatWeeks = Math.floor(repeatWeeksNumber);
+
+            const parseDate = (value: any, field: string, allowNull = false): Date | null => {
+                if (value === undefined) {
+                    if (allowNull) {
+                        return null;
+                    }
+                    throw new Error(`${field} is required`);
+                }
+                if (allowNull && (value === null || value === "")) {
+                    return null;
+                }
+                const date = new Date(value);
+                if (Number.isNaN(date.getTime())) {
+                    throw new Error(`Invalid ${field}`);
+                }
+                return date;
             };
 
-            const shift = await this.service.create(data);
+            const parseNumber = (value: any, field: string): number => {
+                if (value === undefined || value === null || value === "") {
+                    throw new Error(`Invalid ${field}`);
+                }
+                const num = Number(value);
+                if (Number.isNaN(num)) {
+                    throw new Error(`Invalid ${field}`);
+                }
+                return num;
+            };
+
+            const chatterId = parseNumber(req.body.chatterId, "chatterId");
+            const statusInput = (req.body.status ?? "scheduled") as ShiftStatus;
+            if (!VALID_SHIFT_STATUSES.includes(statusInput)) {
+                res.status(400).send("Invalid status");
+                return;
+            }
+            const status = statusInput;
+
+            const startTime = parseDate(req.body.start_time ?? req.body.startTime, "start_time");
+            const date = parseDate(req.body.date, "date");
+            const endTime = parseDate(req.body.end_time ?? req.body.endTime, "end_time", true);
+
+            const modelIds = Array.isArray(req.body.modelIds)
+                ? req.body.modelIds.map((n: any) => {
+                    const parsed = Number(n);
+                    if (Number.isNaN(parsed)) {
+                        throw new Error("Invalid modelIds entry");
+                    }
+                    return parsed;
+                })
+                : [];
+
+            const data: {
+                chatterId: number;
+                status: ShiftStatus;
+                date: Date;
+                start_time: Date;
+                end_time: Date | null;
+                modelIds: number[];
+            } = {
+                chatterId,
+                status,
+                date: date!,
+                start_time: startTime!,
+                end_time: endTime,
+                modelIds,
+            };
+
+            const shift = await this.service.create(data, {repeatWeekly, repeatWeeks});
             res.status(201).json(shift.toJSON());
         } catch (err) {
             console.error(err);
-            res.status(500).send("Error creating shift");
+            if (err instanceof Error && err.message.startsWith("Invalid")) {
+                res.status(400).send(err.message);
+            } else if (err instanceof Error && err.message.endsWith("required")) {
+                res.status(400).send(err.message);
+            } else {
+                res.status(500).send("Error creating shift");
+            }
         }
     }
 
@@ -119,12 +226,103 @@ export class ShiftController {
     public async update(req: Request, res: Response): Promise<void> {
         try {
             const id = Number(req.params.id);
-            const data = {
-                ...req.body,
-                ...(Array.isArray(req.body.modelIds)
-                    ? {modelIds: req.body.modelIds.map((n: any) => Number(n))}
-                    : {}),
+            const data: {
+                chatterId?: number;
+                modelIds?: number[];
+                date?: Date;
+                start_time?: Date;
+                end_time?: Date | null;
+                status?: ShiftStatus;
+            } = {};
+
+            if (req.body.chatterId !== undefined) {
+                if (req.body.chatterId === null || req.body.chatterId === "") {
+                    res.status(400).send("Invalid chatterId");
+                    return;
+                }
+                const parsedChatter = Number(req.body.chatterId);
+                if (Number.isNaN(parsedChatter)) {
+                    res.status(400).send("Invalid chatterId");
+                    return;
+                }
+                data.chatterId = parsedChatter;
+            }
+
+            if (req.body.modelIds !== undefined) {
+                if (!Array.isArray(req.body.modelIds)) {
+                    res.status(400).send("modelIds must be an array");
+                    return;
+                }
+                try {
+                    data.modelIds = req.body.modelIds.map((n: any) => {
+                        const parsed = Number(n);
+                        if (Number.isNaN(parsed)) {
+                            throw new Error("Invalid modelIds entry");
+                        }
+                        return parsed;
+                    });
+                } catch (error) {
+                    if (error instanceof Error && error.message.startsWith("Invalid")) {
+                        res.status(400).send(error.message);
+                        return;
+                    }
+                    throw error;
+                }
+            }
+
+            if (req.body.date !== undefined) {
+                const parsedDate = new Date(req.body.date);
+                if (Number.isNaN(parsedDate.getTime())) {
+                    res.status(400).send("Invalid date");
+                    return;
+                }
+                data.date = parsedDate;
+            }
+
+            const mapOptionalDate = (value: any, field: string, allowNull = false): Date | null | undefined => {
+                if (value === undefined) {
+                    return undefined;
+                }
+                if (allowNull && (value === null || value === "")) {
+                    return null;
+                }
+                const parsed = new Date(value);
+                if (Number.isNaN(parsed.getTime())) {
+                    throw new Error(`Invalid ${field}`);
+                }
+                return parsed;
             };
+
+            try {
+                const startTime = mapOptionalDate(req.body.start_time ?? req.body.startTime, "start_time");
+                if (startTime !== undefined) {
+                    if (startTime === null) {
+                        res.status(400).send("Invalid start_time");
+                        return;
+                    }
+                    data.start_time = startTime;
+                }
+                const endTime = mapOptionalDate(req.body.end_time ?? req.body.endTime, "end_time", true);
+                if (endTime !== undefined) {
+                    data.end_time = endTime;
+                }
+            } catch (error) {
+                if (error instanceof Error && error.message.startsWith("Invalid")) {
+                    res.status(400).send(error.message);
+                    return;
+                }
+                throw error;
+            }
+
+            if (req.body.status !== undefined) {
+                const status = req.body.status as ShiftStatus;
+                if (!VALID_SHIFT_STATUSES.includes(status)) {
+                    res.status(400).send("Invalid status");
+                    return;
+                }
+                data.status = status;
+            }
+
             const shift = await this.service.update(id, data);
             if (!shift) {
                 res.status(404).send("Shift not found");
@@ -133,7 +331,11 @@ export class ShiftController {
             res.json(shift.toJSON());
         } catch (err) {
             console.error(err);
-            res.status(500).send("Error updating shift");
+            if (err instanceof Error && err.message.startsWith("Invalid")) {
+                res.status(400).send(err.message);
+            } else {
+                res.status(500).send("Error updating shift");
+            }
         }
     }
 

--- a/src/data/interfaces/IShiftRepository.ts
+++ b/src/data/interfaces/IShiftRepository.ts
@@ -8,7 +8,11 @@ import {ShiftStatus} from "../../rename/types";
  * IShiftRepository interface.
  */
 export interface IShiftRepository {
-    findAll(): Promise<ShiftModel[]>;
+    findAll(filters?: {
+        from?: Date;
+        to?: Date;
+        chatterId?: number;
+    }): Promise<ShiftModel[]>;
     findById(id: number): Promise<ShiftModel | null>;
     create(data: {
         chatterId: number;

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -49,7 +49,8 @@ export const authenticateToken = (req: AuthenticatedRequest, res: Response, next
         return;
     }
 
-    jwt.verify(token, process.env.JWT_SECRET as string, (err: jwt.VerifyErrors | null, user: JwtPayload | undefined) => {
+    jwt.verify(token, process.env.JWT_SECRET as string, (err, decoded) => {
+        const user = decoded as JwtPayload | undefined;
         if (err || !user?.userId) {
             res.sendStatus(403); // Forbidden - No return needed
             return;


### PR DESCRIPTION
## Summary
- add filtering for shift listings so optional date and chatter filters reduce results
- support weekly repeating shift creation and accept expanded payload validations
- allow shift updates for time, date, chatter, and models while keeping metadata intact

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ca84d2dde48327bcfe7f84d3208c5f