### PR TITLE
Add day grouping support to commissions API

### DIFF
--- a/src/data/repositories/CommissionRepository.ts
+++ b/src/data/repositories/CommissionRepository.ts
@@ -26,19 +26,23 @@ export class CommissionRepository extends BaseRepository implements ICommissionR
         }
         if (params.date !== undefined) {
             conditions.push("DATE(commission_date) = ?");
-            values.push(params.date.toISOString().slice(0, 10));
+            values.push(this.formatDate(params.date));
         }
         if (params.from !== undefined) {
-            conditions.push("commission_date >= ?");
-            values.push(params.from);
+            conditions.push("DATE(commission_date) >= ?");
+            values.push(this.formatDate(params.from));
         }
         if (params.to !== undefined) {
-            conditions.push("commission_date <= ?");
-            values.push(params.to);
+            conditions.push("DATE(commission_date) <= ?");
+            values.push(this.formatDate(params.to));
         }
 
         const whereClause = conditions.length ? ` WHERE ${conditions.join(" AND ")}` : "";
         return { whereClause, values };
+    }
+
+    private formatDate(value: Date): string {
+        return value.toISOString().slice(0, 10);
     }
 
     public async findAll(params: {
@@ -66,7 +70,6 @@ export class CommissionRepository extends BaseRepository implements ICommissionR
         }
 
         const rows = await this.execute<RowDataPacket[]>(query, dataValues);
-        console.log(rows)
         return rows.map(CommissionModel.fromRow);
     }
 


### PR DESCRIPTION
## Summary
- add optional groupBy=day handling for the commissions listing with daily aggregates and totals
- ensure grouped responses honour chatter, date, and range filters while emitting empty days inside the window
- normalize repository filters to compare on DATE columns so combined from/to/date constraints are consistently applied

## Testing
- npm run lint *(fails: ESLint couldn't find an eslint.config file)*

------
https://chatgpt.com/codex/tasks/task_e_68cab38d0700832789e5306f2281ea62