### PR TITLE
Add date range filtering to analytics endpoints

### DIFF
--- a/src/business/services/ModelService.ts
+++ b/src/business/services/ModelService.ts
@@ -61,7 +61,7 @@ export class ModelService {
     /**
      * Returns all models with their total earnings before commissions.
      */
-    public async getEarnings(): Promise<ModelEarningsModel[]> {
-        return this.modelRepo.findAllWithEarnings();
+    public async getEarnings(params: {from?: Date; to?: Date;} = {}): Promise<ModelEarningsModel[]> {
+        return this.modelRepo.findAllWithEarnings(params);
     }
 }

--- a/src/business/services/RevenueService.ts
+++ b/src/business/services/RevenueService.ts
@@ -16,8 +16,8 @@ export class RevenueService {
         private txnSync: F2FTransactionSyncService,
     ) {}
 
-    public async getEarnings(): Promise<RevenueModel[]> {
+    public async getEarnings(params: {from?: Date; to?: Date;} = {}): Promise<RevenueModel[]> {
         await this.txnSync.syncRecentTransactions().catch(console.error);
-        return await this.earningRepo.findAllWithCommissionRates();
+        return await this.earningRepo.findAllWithCommissionRates(params);
     }
 }

--- a/src/controllers/EmployeeEarningController.ts
+++ b/src/controllers/EmployeeEarningController.ts
@@ -220,12 +220,34 @@ export class EmployeeEarningController {
 
     /**
      * Retrieves leaderboard data per chatter.
-     * @param _req Express request object.
+     * @param req Express request object.
      * @param res Express response object.
      */
-    public async getLeaderboard(_req: Request, res: Response): Promise<void> {
+    public async getLeaderboard(req: Request, res: Response): Promise<void> {
         try {
-            const data = await this.service.getLeaderboard();
+            const fromStr = this.extractString(req.query.from);
+            let from: Date | undefined;
+            if (fromStr) {
+                from = new Date(fromStr);
+                if (isNaN(from.getTime())) {
+                    res.status(400).send("Invalid from date");
+                    return;
+                }
+            }
+            const toStr = this.extractString(req.query.to);
+            let to: Date | undefined;
+            if (toStr) {
+                to = new Date(toStr);
+                if (isNaN(to.getTime())) {
+                    res.status(400).send("Invalid to date");
+                    return;
+                }
+            }
+            if (from && to && from > to) {
+                res.status(400).send("'from' date must be before 'to' date");
+                return;
+            }
+            const data = await this.service.getLeaderboard({from, to});
             res.json(data.map(d => d.toJSON()));
         } catch (err) {
             console.error(err);

--- a/src/controllers/RevenueController.ts
+++ b/src/controllers/RevenueController.ts
@@ -13,13 +13,49 @@ export class RevenueController {
         return container.resolve(RevenueService);
     }
 
-    public async getEarnings(_req: Request, res: Response): Promise<void> {
+    public async getEarnings(req: Request, res: Response): Promise<void> {
         try {
-            const earnings = await this.service.getEarnings();
+            const fromStr = this.extractString(req.query.from);
+            let from: Date | undefined;
+            if (fromStr) {
+                from = new Date(fromStr);
+                if (isNaN(from.getTime())) {
+                    res.status(400).send("Invalid from date");
+                    return;
+                }
+            }
+            const toStr = this.extractString(req.query.to);
+            let to: Date | undefined;
+            if (toStr) {
+                to = new Date(toStr);
+                if (isNaN(to.getTime())) {
+                    res.status(400).send("Invalid to date");
+                    return;
+                }
+            }
+            if (from && to && from > to) {
+                res.status(400).send("'from' date must be before 'to' date");
+                return;
+            }
+            const earnings = await this.service.getEarnings({from, to});
             res.json(earnings);
         } catch (err) {
             console.error(err);
             res.status(500).send("Error fetching revenue earnings");
         }
+    }
+
+    private extractString(value: unknown): string | undefined {
+        if (typeof value === "string") {
+            return value;
+        }
+        if (Array.isArray(value)) {
+            for (const item of value) {
+                if (typeof item === "string") {
+                    return item;
+                }
+            }
+        }
+        return undefined;
     }
 }

--- a/src/data/interfaces/IEmployeeEarningRepository.ts
+++ b/src/data/interfaces/IEmployeeEarningRepository.ts
@@ -51,7 +51,12 @@ export interface IEmployeeEarningRepository {
 
     findByChatter(chatterId: number): Promise<EmployeeEarningModel[]>;
 
-    getLeaderboard(startOfWeek: Date, startOfMonth: Date): Promise<{
+    getLeaderboard(params: {
+        startOfWeek: Date;
+        startOfMonth: Date;
+        from?: Date;
+        to?: Date;
+    }): Promise<{
         chatterId: number;
         chatterName: string;
         weekAmount: number;
@@ -60,5 +65,5 @@ export interface IEmployeeEarningRepository {
 
     findWithoutChatterBetween(start: Date, end: Date): Promise<EmployeeEarningModel[]>;
 
-    findAllWithCommissionRates(): Promise<RevenueModel[]>;
+    findAllWithCommissionRates(params?: {from?: Date; to?: Date;}): Promise<RevenueModel[]>;
 }

--- a/src/data/interfaces/IModelRepository.ts
+++ b/src/data/interfaces/IModelRepository.ts
@@ -13,5 +13,5 @@ export interface IModelRepository {
     create(data: { displayName: string; username: string; commissionRate: number; }): Promise<ModelModel>;
     update(id: number, data: { displayName?: string; username?: string; commissionRate?: number; }): Promise<ModelModel | null>;
     delete(id: number): Promise<void>;
-    findAllWithEarnings(): Promise<ModelEarningsModel[]>;
+    findAllWithEarnings(params?: {from?: Date; to?: Date;}): Promise<ModelEarningsModel[]>;
 }


### PR DESCRIPTION
## Summary
- add optional from/to query handling to leaderboard, model earnings, and revenue endpoints
- propagate date range constraints through services and repositories so analytics respect inclusive month windows

## Testing
- npm install *(fails: 403 Forbidden downloading npm-11.5.2.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_68cbf305b3a08327b917f744e466e810