### PR TITLE
feat: add analytics earnings profit trend endpoint

### DIFF
--- a/src/business/models/RevenueModel.ts
+++ b/src/business/models/RevenueModel.ts
@@ -12,6 +12,7 @@ export class RevenueModel {
         private _modelCommissionRate: number | null,
         private _chatterId: number | null,
         private _chatterCommissionRate: number | null,
+        private _platformFeeRate: number | null,
         private _date: Date,
     ) {}
 
@@ -23,6 +24,7 @@ export class RevenueModel {
             modelCommissionRate: this.modelCommissionRate,
             chatterId: this.chatterId,
             chatterCommissionRate: this.chatterCommissionRate,
+            platformFeeRate: this.platformFeeRate,
             date: this.date,
         };
     }
@@ -33,6 +35,7 @@ export class RevenueModel {
     get modelCommissionRate(): number | null { return this._modelCommissionRate; }
     get chatterId(): number | null { return this._chatterId; }
     get chatterCommissionRate(): number | null { return this._chatterCommissionRate; }
+    get platformFeeRate(): number | null { return this._platformFeeRate; }
     get date(): Date { return this._date; }
 
     static fromRow(row: any): RevenueModel {
@@ -43,6 +46,7 @@ export class RevenueModel {
             row.model_commission_rate,
             row.chatter_id,
             row.chatter_commission_rate,
+            row.platform_fee,
             new Date(row.date),
         );
     }

--- a/src/business/services/AnalyticsService.ts
+++ b/src/business/services/AnalyticsService.ts
@@ -1,0 +1,166 @@
+import {injectable} from "tsyringe";
+import {RevenueService} from "./RevenueService";
+import {formatInTimeZone, utcToZonedTime, zonedTimeToUtc} from "date-fns-tz";
+import {addDays, addMonths, isAfter, startOfDay, startOfMonth} from "date-fns";
+
+export type AnalyticsInterval = "day" | "month";
+
+export interface EarningsProfitTrendPoint {
+    key: string;
+    label: string;
+    tooltipLabel: string;
+    earnings: number;
+    profit: number;
+}
+
+export interface EarningsProfitTrendResult {
+    range: string;
+    interval: AnalyticsInterval;
+    from: string;
+    to: string;
+    points: EarningsProfitTrendPoint[];
+    totals: {
+        earnings: number;
+        profit: number;
+    };
+}
+
+interface EarningsProfitTrendParams {
+    from: string;
+    to: string;
+    interval: AnalyticsInterval;
+    timezone: string;
+}
+
+@injectable()
+export class AnalyticsService {
+    constructor(private revenueService: RevenueService) {}
+
+    public async getEarningsProfitTrend(params: EarningsProfitTrendParams): Promise<EarningsProfitTrendResult> {
+        const {from, to, interval, timezone} = params;
+
+        const fromUtc = zonedTimeToUtc(`${from}T00:00:00`, timezone);
+        const toUtc = zonedTimeToUtc(`${to}T23:59:59.999`, timezone);
+
+        if (fromUtc > toUtc) {
+            throw new Error("'from' date must be before or equal to 'to'");
+        }
+
+        const {points, map} = this.buildBuckets({fromUtc, toUtc, interval, timezone});
+
+        const earnings = await this.revenueService.getEarnings({from: fromUtc, to: toUtc});
+
+        for (const record of earnings) {
+            const bucketKey = this.getBucketKey(record.date, interval, timezone);
+            const bucket = map.get(bucketKey);
+            if (!bucket) continue;
+
+            const amount = Number(record.amount ?? 0);
+            bucket.earnings += amount;
+
+            const platformFeeRate = Number(record.platformFeeRate ?? 0);
+            const net = amount * (1 - platformFeeRate / 100);
+            const modelCommissionRate = Number(record.modelCommissionRate ?? 0);
+            const chatterCommissionRate = Number(record.chatterCommissionRate ?? 0);
+            const modelCommission = net * (modelCommissionRate / 100);
+            const chatterCommission = net * (chatterCommissionRate / 100);
+            const profit = net - modelCommission - chatterCommission;
+            bucket.profit += profit;
+        }
+
+        let totalEarnings = 0;
+        let totalProfit = 0;
+        for (const point of points) {
+            point.earnings = Number(point.earnings.toFixed(2));
+            point.profit = Number(point.profit.toFixed(2));
+            totalEarnings += point.earnings;
+            totalProfit += point.profit;
+        }
+
+        const range = this.deriveRange(interval, points.length);
+
+        return {
+            range,
+            interval,
+            from,
+            to,
+            points,
+            totals: {
+                earnings: Number(totalEarnings.toFixed(2)),
+                profit: Number(totalProfit.toFixed(2)),
+            },
+        };
+    }
+
+    private buildBuckets(params: {
+        fromUtc: Date;
+        toUtc: Date;
+        interval: AnalyticsInterval;
+        timezone: string;
+    }): {points: EarningsProfitTrendPoint[]; map: Map<string, EarningsProfitTrendPoint>;} {
+        const {fromUtc, toUtc, interval, timezone} = params;
+        const points: EarningsProfitTrendPoint[] = [];
+        const map = new Map<string, EarningsProfitTrendPoint>();
+
+        if (interval === "day") {
+            let cursorZoned = startOfDay(utcToZonedTime(fromUtc, timezone));
+            const endZoned = startOfDay(utcToZonedTime(toUtc, timezone));
+
+            while (!isAfter(cursorZoned, endZoned)) {
+                const cursorUtc = zonedTimeToUtc(cursorZoned, timezone);
+                const key = this.getBucketKey(cursorUtc, interval, timezone);
+                const point: EarningsProfitTrendPoint = {
+                    key,
+                    label: formatInTimeZone(cursorUtc, timezone, "d"),
+                    tooltipLabel: formatInTimeZone(cursorUtc, timezone, "d MMM yyyy"),
+                    earnings: 0,
+                    profit: 0,
+                };
+                points.push(point);
+                map.set(key, point);
+                cursorZoned = addDays(cursorZoned, 1);
+            }
+        } else {
+            let cursorZoned = startOfMonth(utcToZonedTime(fromUtc, timezone));
+            const endZoned = startOfMonth(utcToZonedTime(toUtc, timezone));
+
+            while (!isAfter(cursorZoned, endZoned)) {
+                const cursorUtc = zonedTimeToUtc(cursorZoned, timezone);
+                const key = this.getBucketKey(cursorUtc, interval, timezone);
+                const point: EarningsProfitTrendPoint = {
+                    key,
+                    label: formatInTimeZone(cursorUtc, timezone, "MMM"),
+                    tooltipLabel: formatInTimeZone(cursorUtc, timezone, "MMM yyyy"),
+                    earnings: 0,
+                    profit: 0,
+                };
+                points.push(point);
+                map.set(key, point);
+                cursorZoned = addMonths(cursorZoned, 1);
+            }
+        }
+
+        return {points, map};
+    }
+
+    private getBucketKey(date: Date, interval: AnalyticsInterval, timezone: string): string {
+        if (interval === "day") {
+            return formatInTimeZone(date, timezone, "yyyy-MM-dd");
+        }
+        return formatInTimeZone(date, timezone, "yyyy-MM-01");
+    }
+
+    private deriveRange(interval: AnalyticsInterval, bucketCount: number): string {
+        if (interval === "day") {
+            if (bucketCount <= 7) {
+                return "week";
+            }
+            if (bucketCount <= 31) {
+                return "month";
+            }
+        } else if (bucketCount <= 12) {
+            return "year";
+        }
+        return "custom";
+    }
+}

--- a/src/container/index.ts
+++ b/src/container/index.ts
@@ -23,6 +23,7 @@ import {ModelService} from "../business/services/ModelService";
 import {IModelRepository} from "../data/interfaces/IModelRepository";
 import {ModelRepository} from "../data/repositories/ModelRepository";
 import {RevenueService} from "../business/services/RevenueService";
+import {AnalyticsService} from "../business/services/AnalyticsService";
 
 container.register("UserService", { useClass: UserService });
 
@@ -56,3 +57,4 @@ container.register<IModelRepository>("IModelRepository", {
 container.register("F2FUnlockSyncService", { useClass: F2FUnlockSyncService });
 container.registerSingleton(F2FTransactionSyncService);
 container.register("RevenueService", { useClass: RevenueService });
+container.register("AnalyticsService", { useClass: AnalyticsService });

--- a/src/controllers/AnalyticsController.ts
+++ b/src/controllers/AnalyticsController.ts
@@ -1,0 +1,94 @@
+import {Request, Response} from "express";
+import {container} from "tsyringe";
+import {AnalyticsInterval, AnalyticsService} from "../business/services/AnalyticsService";
+
+export class AnalyticsController {
+    private get service(): AnalyticsService {
+        return container.resolve(AnalyticsService);
+    }
+
+    public async getEarningsProfitTrend(req: Request, res: Response): Promise<void> {
+        try {
+            const from = this.extractDate(req.query.from);
+            const to = this.extractDate(req.query.to);
+            const interval = this.extractInterval(req.query.interval);
+
+            if (!from || !to) {
+                res.status(400).send("'from' and 'to' query parameters are required in YYYY-MM-DD format");
+                return;
+            }
+
+            if (!interval) {
+                res.status(400).send("'interval' query parameter must be either 'day' or 'month'");
+                return;
+            }
+
+            if (from > to) {
+                res.status(400).send("'from' date must be before or equal to 'to'");
+                return;
+            }
+
+            const timezoneInput = this.extractString(req.query.timezone);
+            let effectiveTimezone = process.env.TZ ?? "UTC";
+            if (timezoneInput) {
+                if (!this.isValidTimezone(timezoneInput)) {
+                    res.status(400).send("Invalid timezone provided");
+                    return;
+                }
+                effectiveTimezone = timezoneInput;
+            }
+
+            const result = await this.service.getEarningsProfitTrend({
+                from,
+                to,
+                interval,
+                timezone: effectiveTimezone,
+            });
+
+            res.json(result);
+        } catch (error) {
+            console.error(error);
+            res.status(500).send("Error generating earnings and profit trend");
+        }
+    }
+
+    private extractDate(value: unknown): string | undefined {
+        const text = this.extractString(value);
+        if (!text) return undefined;
+        if (!/^\d{4}-\d{2}-\d{2}$/.test(text)) {
+            return undefined;
+        }
+        return text;
+    }
+
+    private extractInterval(value: unknown): AnalyticsInterval | undefined {
+        const text = this.extractString(value);
+        if (text === "day" || text === "month") {
+            return text;
+        }
+        return undefined;
+    }
+
+    private isValidTimezone(value: string): boolean {
+        try {
+            new Intl.DateTimeFormat(undefined, { timeZone: value });
+            return true;
+        } catch {
+            return false;
+        }
+    }
+
+    private extractString(value: unknown): string | undefined {
+        if (typeof value === "string") {
+            return value;
+        }
+        if (Array.isArray(value)) {
+            for (const item of value) {
+                if (typeof item === "string") {
+                    return item;
+                }
+            }
+        }
+        return undefined;
+    }
+}

--- a/src/data/repositories/EmployeeEarningRepository.ts
+++ b/src/data/repositories/EmployeeEarningRepository.ts
@@ -318,6 +318,7 @@ export class EmployeeEarningRepository extends BaseRepository implements IEmploy
                     m.commission_rate AS model_commission_rate,
                     ee.chatter_id,
                     c.commission_rate AS chatter_commission_rate,
+                    c.platform_fee,
                     ee.date
              FROM employee_earnings ee
                       LEFT JOIN models m ON ee.model_id = m.id

--- a/src/routes/AnalyticsRoute.ts
+++ b/src/routes/AnalyticsRoute.ts
@@ -1,0 +1,10 @@
+import {Router} from "express";
+import {authenticateToken} from "../middleware/auth";
+import {AnalyticsController} from "../controllers/AnalyticsController";
+
+const router = Router();
+const controller = new AnalyticsController();
+
+router.get("/earnings-profit-trend", authenticateToken, controller.getEarningsProfitTrend.bind(controller));
+
+export default router;

--- a/src/server.ts
+++ b/src/server.ts
@@ -14,6 +14,7 @@ import shiftRoute from "./routes/ShiftRoute";
 import modelRoute from "./routes/ModelRoute";
 import revenueRoute from "./routes/RevenueRoute";
 import commissionRoute from "./routes/CommissionRoute";
+import analyticsRoute from "./routes/AnalyticsRoute";
 
 import cors from "cors";
 
@@ -64,6 +65,7 @@ app.use("/api/shifts", shiftRoute);
 app.use("/api/models", modelRoute);
 app.use("/api/revenue", revenueRoute);
 app.use("/api/commissions", commissionRoute);
+app.use("/api/analytics", analyticsRoute);
 
 // Health
 app.get("/api/health", (_req, res) => res.json({ ok: true }));


### PR DESCRIPTION
## Summary
- add an analytics service that aggregates earnings and profit per bucket with timezone-aware boundaries and totals
- expose the authenticated GET /analytics/earnings-profit-trend endpoint with request validation for dates, interval, and timezone
- include platform fee data on revenue models and wire the analytics route into the server and dependency container

## Testing
- `npm run lint` *(fails: ESLint config missing in repo)*

------
https://chatgpt.com/codex/tasks/task_e_68cebf5be9a0832781b1071578b83fda