### PR TITLE
Refine revenue range boundaries with timezone-safe helpers

### DIFF
--- a/src/business/services/RevenueService.ts
+++ b/src/business/services/RevenueService.ts
@@ -1,8 +1,8 @@
 /**
  * RevenueService module.
  */
-import {endOfDay, endOfMonth, startOfDay, startOfMonth, startOfWeek} from "date-fns";
-import {toZonedTime, fromZonedTime} from "date-fns-tz";
+import {addDays} from "date-fns";
+import {formatInTimeZone} from "date-fns-tz";
 import {inject, injectable} from "tsyringe";
 import {IEmployeeEarningRepository} from "../../data/interfaces/IEmployeeEarningRepository";
 import {F2FTransactionSyncService} from "./F2FTransactionSyncService";
@@ -28,36 +28,29 @@ export class RevenueService {
 
         const timezone = process.env.TZ ?? "UTC";
         const now = new Date();
-        const nowZoned = toZonedTime(now, timezone);
 
-        const effectiveFrom = params.from
-            ? fromZonedTime(startOfDay(toZonedTime(params.from, timezone)), timezone)
-            : undefined;
-        const effectiveTo = params.to
-            ? fromZonedTime(endOfDay(toZonedTime(params.to, timezone)), timezone)
-            : undefined;
+        const effectiveFrom = params.from ? this.getDayStart(params.from, timezone) : undefined;
+        const effectiveTo = params.to ? this.getDayEnd(params.to, timezone) : undefined;
 
-        const todayStart = fromZonedTime(startOfDay(nowZoned), timezone);
-        const todayEnd = fromZonedTime(endOfDay(nowZoned), timezone);
-        console.log(todayStart, todayEnd)
+        const todayStart = this.getDayStart(now, timezone);
+        const todayEnd = this.getDayEnd(now, timezone);
         const daily = await this.earningRepo.getTotalAmount({from: todayStart, to: todayEnd});
 
-        const monthFrom = effectiveFrom ?? fromZonedTime(startOfMonth(nowZoned), timezone);
-        const monthTo = effectiveTo ?? fromZonedTime(endOfMonth(nowZoned), timezone);
+        const monthFrom = effectiveFrom ?? this.getMonthStart(now, timezone);
+        const monthTo = effectiveTo ?? this.getMonthEnd(now, timezone);
 
         let monthly = 0;
         if (monthTo >= monthFrom) {
             monthly = await this.earningRepo.getTotalAmount({from: monthFrom, to: monthTo});
         }
 
-        const referenceForWeekUtc = effectiveTo ?? now;
-        const referenceForWeekZoned = toZonedTime(referenceForWeekUtc, timezone);
-        let weekFrom = fromZonedTime(startOfWeek(referenceForWeekZoned, {weekStartsOn: 1}), timezone);
+        const referenceForWeek = effectiveTo ?? now;
+        let weekFrom = this.getWeekStart(referenceForWeek, timezone);
         if (effectiveFrom && weekFrom < effectiveFrom) {
             weekFrom = effectiveFrom;
         }
 
-        const weekTo = effectiveTo ?? fromZonedTime(endOfDay(referenceForWeekZoned), timezone);
+        const weekTo = effectiveTo ?? this.getDayEnd(referenceForWeek, timezone);
 
         let weekly = 0;
         if (weekTo >= weekFrom) {
@@ -65,5 +58,49 @@ export class RevenueService {
         }
 
         return {daily, weekly, monthly};
+    }
+
+    private getDayStart(date: Date, timezone: string): Date {
+        const {year, month, day} = this.extractDateParts(date, timezone);
+        return this.buildUtcDate(year, month, day);
+    }
+
+    private getDayEnd(date: Date, timezone: string): Date {
+        const nextDayParts = this.extractDateParts(addDays(date, 1), timezone);
+        const nextDayStart = this.buildUtcDate(nextDayParts.year, nextDayParts.month, nextDayParts.day);
+        return new Date(nextDayStart.getTime() - 1);
+    }
+
+    private getMonthStart(date: Date, timezone: string): Date {
+        const monthStr = formatInTimeZone(date, timezone, "yyyy-MM");
+        const [yearStr, monthStrNum] = monthStr.split("-");
+        return this.buildUtcDate(Number(yearStr), Number(monthStrNum), 1);
+    }
+
+    private getMonthEnd(date: Date, timezone: string): Date {
+        const monthStr = formatInTimeZone(date, timezone, "yyyy-MM");
+        const [yearStr, monthStrNum] = monthStr.split("-");
+        const year = Number(yearStr);
+        const month = Number(monthStrNum);
+        const nextYear = month === 12 ? year + 1 : year;
+        const nextMonth = month === 12 ? 1 : month + 1;
+        const nextMonthStart = this.buildUtcDate(nextYear, nextMonth, 1);
+        return new Date(nextMonthStart.getTime() - 1);
+    }
+
+    private getWeekStart(date: Date, timezone: string): Date {
+        const isoDay = Number(formatInTimeZone(date, timezone, "i"));
+        const daysToSubtract = isoDay - 1;
+        const startCandidate = addDays(date, -daysToSubtract);
+        return this.getDayStart(startCandidate, timezone);
+    }
+
+    private extractDateParts(date: Date, timezone: string): {year: number; month: number; day: number;} {
+        const [yearStr, monthStr, dayStr] = formatInTimeZone(date, timezone, "yyyy-M-d").split("-");
+        return {year: Number(yearStr), month: Number(monthStr), day: Number(dayStr)};
+    }
+
+    private buildUtcDate(year: number, month: number, day: number, hours = 0, minutes = 0, seconds = 0, milliseconds = 0): Date {
+        return new Date(Date.UTC(year, month - 1, day, hours, minutes, seconds, milliseconds));
     }
 }


### PR DESCRIPTION
## Summary
- rebuild revenue range calculations so day, week, and month windows are reconstructed from timezone-local calendar components before building the Date instances
- replace the prior helper with UTC-aligned builders that rely on `formatInTimeZone` to derive calendar parts and `Date.UTC` to produce midnight start and end boundaries

## Testing
- npm run lint *(fails: ESLint configuration file missing in repo)*

------
https://chatgpt.com/codex/tasks/task_e_68ced46fe384832795545cbd50840617