### PR TITLE
Add detailed logging for earning commission workflows

### DIFF
--- a/src/business/services/EmployeeEarningService.ts
+++ b/src/business/services/EmployeeEarningService.ts
@@ -148,7 +148,13 @@ export class EmployeeEarningService {
      * @param data Earning details.
      */
     public async create(data: { chatterId: number | null; modelId: number | null; date: Date; amount: number; description?: string | null; type?: string | null; }): Promise<EmployeeEarningModel> {
-        return this.earningRepo.create(data);
+        console.log(`EmployeeEarningService.create: creating earning with data ${JSON.stringify(data)}`);
+        const created = await this.earningRepo.create(data);
+
+        console.log(`EmployeeEarningService.create: created earning ${created.id}`);
+        await this.refreshCommissionsForNewEarning(created);
+
+        return created;
     }
 
     /**
@@ -157,17 +163,23 @@ export class EmployeeEarningService {
      * @param data Partial earning data.
      */
     public async update(id: string, data: { chatterId?: number | null; modelId?: number | null; date?: Date; amount?: number; description?: string | null; type?: string | null; }): Promise<EmployeeEarningModel | null> {
+        console.log(`EmployeeEarningService.update: fetching earning ${id} before update`);
         const before = await this.earningRepo.findById(id);
         if (!before) {
+            console.log(`EmployeeEarningService.update: earning ${id} not found`);
             return null;
         }
 
+        console.log(`EmployeeEarningService.update: current earning ${id} -> ${JSON.stringify(before)}`);
+        console.log(`EmployeeEarningService.update: applying changes ${JSON.stringify(data)}`);
         const updated = await this.earningRepo.update(id, data);
 
         if (!updated) {
+            console.log(`EmployeeEarningService.update: repository returned null for earning ${id}`);
             return null;
         }
 
+        console.log(`EmployeeEarningService.update: updated earning ${id} -> ${JSON.stringify(updated)}`);
         await this.refreshCommissionsForEarningChange(before, updated);
 
         return updated;
@@ -182,40 +194,68 @@ export class EmployeeEarningService {
     }
 
     private async refreshCommissionsForEarningChange(before: EmployeeEarningModel, after: EmployeeEarningModel): Promise<void> {
+        console.log(`EmployeeEarningService.refreshCommissionsForEarningChange: evaluating earning ${before.id}`);
         const shifts = new Map<number, ShiftModel>();
 
         const beforeShift = await this.resolveCompletedShiftForEarning(before);
         if (beforeShift) {
+            console.log(`EmployeeEarningService.refreshCommissionsForEarningChange: found previous shift ${beforeShift.id}`);
             shifts.set(beforeShift.id, beforeShift);
+        } else {
+            console.log("EmployeeEarningService.refreshCommissionsForEarningChange: no previous completed shift found");
         }
 
         const afterShift = await this.resolveCompletedShiftForEarning(after);
 
         if (afterShift) {
+            console.log(`EmployeeEarningService.refreshCommissionsForEarningChange: found new shift ${afterShift.id}`);
             shifts.set(afterShift.id, afterShift);
+        } else {
+            console.log("EmployeeEarningService.refreshCommissionsForEarningChange: no new completed shift found");
         }
 
         for (const shift of shifts.values()) {
+            console.log(`EmployeeEarningService.refreshCommissionsForEarningChange: recalculating commission for shift ${shift.id}`);
             await this.commissionService.recalculateCommissionForShift(shift);
         }
     }
 
+    private async refreshCommissionsForNewEarning(earning: EmployeeEarningModel): Promise<void> {
+        console.log(`EmployeeEarningService.refreshCommissionsForNewEarning: resolving shift for earning ${earning.id}`);
+        const shift = await this.resolveCompletedShiftForEarning(earning);
+        if (!shift) {
+            console.log("EmployeeEarningService.refreshCommissionsForNewEarning: no completed shift found");
+            return;
+        }
+
+        console.log(`EmployeeEarningService.refreshCommissionsForNewEarning: recalculating commission for shift ${shift.id}`);
+        await this.commissionService.recalculateCommissionForShift(shift);
+    }
+
     private async resolveCompletedShiftForEarning(earning: EmployeeEarningModel): Promise<ShiftModel | null> {
+        console.log(`EmployeeEarningService.resolveCompletedShiftForEarning: resolving for earning ${earning.id}`);
         if (!earning.chatterId) {
+            console.log("EmployeeEarningService.resolveCompletedShiftForEarning: earning has no chatterId");
             return null;
         }
 
+        const earningDate = earning.date instanceof Date ? earning.date.toISOString() : String(earning.date);
+        console.log(`EmployeeEarningService.resolveCompletedShiftForEarning: finding shift for chatter ${earning.chatterId} at ${earningDate}`);
         const shift = await this.shiftRepo.findShiftForChatterAt(earning.chatterId, earning.date);
 
         if (shift && shift.status === "completed") {
+            console.log(`EmployeeEarningService.resolveCompletedShiftForEarning: found matching completed shift ${shift.id}`);
             return shift;
         }
 
+        console.log("EmployeeEarningService.resolveCompletedShiftForEarning: no direct completed shift, searching closest completed shift");
         const closest = await this.shiftRepo.findClosestCompletedShiftForChatter(earning.chatterId, earning.date);
         if (!closest || closest.status !== "completed") {
+            console.log("EmployeeEarningService.resolveCompletedShiftForEarning: no completed shift found in proximity");
             return null;
         }
 
+        console.log(`EmployeeEarningService.resolveCompletedShiftForEarning: using closest completed shift ${closest.id}`);
         return closest;
     }
 }

--- a/src/data/repositories/EmployeeEarningRepository.ts
+++ b/src/data/repositories/EmployeeEarningRepository.ts
@@ -61,7 +61,7 @@ export class EmployeeEarningRepository extends BaseRepository implements IEmploy
                       AND ee.date BETWEEN s.start_time AND COALESCE(s.end_time, NOW())
                       AND (
                           (ee.model_id IS NOT NULL AND sm.model_id = ee.model_id)
-                          OR (ee.model_id IS NULL AND ee.chatter_id = s.chatter_id)
+                          OR ee.chatter_id = s.chatter_id
                       )
                 )`
             );
@@ -135,7 +135,7 @@ export class EmployeeEarningRepository extends BaseRepository implements IEmploy
                       AND employee_earnings.date BETWEEN s.start_time AND COALESCE(s.end_time, NOW())
                       AND (
                           (employee_earnings.model_id IS NOT NULL AND sm.model_id = employee_earnings.model_id)
-                          OR (employee_earnings.model_id IS NULL AND employee_earnings.chatter_id = s.chatter_id)
+                          OR employee_earnings.chatter_id = s.chatter_id
                       )
                 )`
             );


### PR DESCRIPTION
## Summary
- trigger a commission recalculation after creating a new earning
- reuse the existing shift resolution to update the related commission record
- allow shift commission calculations to include earnings matched by chatter even when a model is present so reassigned earnings update totals
- add detailed logging around earning updates and commission recalculations to aid debugging

## Testing
- npm install *(fails: 403 Forbidden - GET https://registry.npmjs.org/date-fns)*

------
https://chatgpt.com/codex/tasks/task_e_68d01f74c814832798fb630d8b1eab8f