### PR TITLE
Ensure employee earnings track shift references

### DIFF
--- a/src/business/models/EmployeeEarningModel.ts
+++ b/src/business/models/EmployeeEarningModel.ts
@@ -10,6 +10,7 @@ export class EmployeeEarningModel {
         private _id: string,
         private _chatterId: number | null,
         private _modelId: number | null,
+        private _shiftId: number | null,
         private _date: Date,           // business date
         private _amount: number,       // decimal(10,2)
         private _description: string | null,
@@ -22,6 +23,7 @@ export class EmployeeEarningModel {
             id: this.id,
             chatterId: this.chatterId,
             modelId: this.modelId,
+            shiftId: this.shiftId,
             date: this.date,
             amount: this.amount,
             description: this.description,
@@ -34,6 +36,7 @@ export class EmployeeEarningModel {
     get id(): string { return this._id; }
     get chatterId(): number | null { return this._chatterId; }
     get modelId(): number | null { return this._modelId; }
+    get shiftId(): number | null { return this._shiftId; }
     get date(): Date { return this._date; }
     get amount(): number { return this._amount; }
     get description(): string | null { return this._description; }
@@ -45,6 +48,7 @@ export class EmployeeEarningModel {
             String(r.id),
             r.chatter_id != null ? Number(r.chatter_id) : null,
             r.model_id != null ? Number(r.model_id) : null,
+            r.shift_id != null ? Number(r.shift_id) : null,
             r.date,
             Number(r.amount),
             r.description != null ? String(r.description) : null,

--- a/src/business/services/EmployeeEarningService.ts
+++ b/src/business/services/EmployeeEarningService.ts
@@ -136,7 +136,7 @@ export class EmployeeEarningService {
             if (!e.modelId) continue;
             const shift = await this.shiftRepo.findShiftForModelAt(e.modelId, e.date);
             if (shift?.chatterId) {
-                await this.earningRepo.update(e.id, {chatterId: shift.chatterId});
+                await this.earningRepo.update(e.id, {chatterId: shift.chatterId, shiftId: shift.id});
                 updated++;
             }
         }
@@ -147,7 +147,7 @@ export class EmployeeEarningService {
      * Creates a new employee earning record.
      * @param data Earning details.
      */
-    public async create(data: { chatterId: number | null; modelId: number | null; date: Date; amount: number; description?: string | null; type?: string | null; }): Promise<EmployeeEarningModel> {
+    public async create(data: { chatterId: number | null; modelId: number | null; shiftId?: number | null; date: Date; amount: number; description?: string | null; type?: string | null; }): Promise<EmployeeEarningModel> {
         return this.earningRepo.create(data);
     }
 
@@ -156,7 +156,7 @@ export class EmployeeEarningService {
      * @param id Earning identifier.
      * @param data Partial earning data.
      */
-    public async update(id: string, data: { chatterId?: number | null; modelId?: number | null; date?: Date; amount?: number; description?: string | null; type?: string | null; }): Promise<EmployeeEarningModel | null> {
+    public async update(id: string, data: { chatterId?: number | null; modelId?: number | null; shiftId?: number | null; date?: Date; amount?: number; description?: string | null; type?: string | null; }): Promise<EmployeeEarningModel | null> {
         const before = await this.earningRepo.findById(id);
         if (!before) {
             return null;
@@ -201,6 +201,13 @@ export class EmployeeEarningService {
     }
 
     private async resolveCompletedShiftForEarning(earning: EmployeeEarningModel): Promise<ShiftModel | null> {
+        if (earning.shiftId) {
+            const shift = await this.shiftRepo.findById(earning.shiftId);
+            if (shift && shift.status === "completed") {
+                return shift;
+            }
+        }
+
         if (!earning.chatterId) {
             return null;
         }

--- a/src/business/services/F2FTransactionSyncService.ts
+++ b/src/business/services/F2FTransactionSyncService.ts
@@ -141,16 +141,19 @@ export class F2FTransactionSyncService {
         const timeStr = ts.toTimeString().split(" ")[0];
 
         let chatterId: number | null = null;
+        let shiftId: number | null = null;
         if (txn.object_type === "paypermessage" || txn.object_type === "tip") {
             const shift = await this.shiftRepo.findShiftForModelAt(model, ts);
             console.log(`  -> model ${creator} id ${model}, found shift: ${shift ? shift.id + ' models:' + shift.modelIds.join(',') : 'NO SHIFT'}`);
             chatterId = shift ? shift.chatterId : null;
+            shiftId = shift ? shift.id : null;
         }
 
         await this.earningRepo.create({
             id,
             chatterId,
             modelId: model ?? null,
+            shiftId,
             date: detail.created,
             amount: revenue,
             description: `F2F: -User: ${detail.user} - Time: ${timeStr}`,

--- a/src/business/services/F2FUnlockSyncService.ts
+++ b/src/business/services/F2FUnlockSyncService.ts
@@ -182,6 +182,7 @@ export class F2FUnlockSyncService {
                     await this.earningRepo.create({
                         chatterId: chatter?.id || 0,
                         modelId: model.id,
+                        shiftId: shift?.id ?? null,
                         date: shift?.date || ts,
                         amount: u.price,
                         description: `unlock: ${creator} @ ${u.datetime.split("T")[0]}`,

--- a/src/data/interfaces/IEmployeeEarningRepository.ts
+++ b/src/data/interfaces/IEmployeeEarningRepository.ts
@@ -33,6 +33,7 @@ export interface IEmployeeEarningRepository {
         id?: string;
         chatterId: number | null;
         modelId: number | null;
+        shiftId?: number | null;
         date: Date;
         amount: number;
         description?: string | null;
@@ -41,6 +42,7 @@ export interface IEmployeeEarningRepository {
     update(id: string, data: {
         chatterId?: number | null;
         modelId?: number | null;
+        shiftId?: number | null;
         date?: Date;
         amount?: number;
         description?: string | null;


### PR DESCRIPTION
## Summary
- add shiftId support to the employee earning model and repository so inserts and updates persist the related shift
- propagate shift identifiers through earning service workflows and F2F sync jobs to keep commission recalculations aligned with the recorded shift

## Testing
- npm run lint *(fails: ESLint couldn't find an eslint.config.* file)*
- npm run build *(fails: missing type declarations for project dependencies in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68df8b07898483278cd91cec63eb7b1a